### PR TITLE
Perform decompression via a thread-local buffer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,6 +88,7 @@ dependencies = [
  "maplit",
  "quickcheck",
  "quickcheck_async",
+ "quickcheck_macros",
  "rand",
  "reqwest",
  "salsa20",
@@ -1156,6 +1157,17 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "247df671941313a4e255a5015772917368f1b21bfedfbd89d68fbb27e802b2fa"
 dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "quickcheck_macros"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "608c156fd8e97febc07dc9c2e2c80bf74cfc6ef26893eae3daf8bc2bc94a4b7f"
+dependencies = [
+ "proc-macro2",
  "quote",
  "syn",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,7 +89,6 @@ dependencies = [
  "quickcheck",
  "quickcheck_async",
  "rand",
- "ref-cast",
  "reqwest",
  "salsa20",
  "serde",
@@ -1216,26 +1215,6 @@ name = "redox_syscall"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
-
-[[package]]
-name = "ref-cast"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "745c1787167ddae5569661d5ffb8b25ae5fedbf46717eaa92d652221cec72623"
-dependencies = [
- "ref-cast-impl",
-]
-
-[[package]]
-name = "ref-cast-impl"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d21b475ab879ef0e315ad99067fa25778c3b0377f57f1b00207448dac1a3144"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "regex"

--- a/banyan/Cargo.toml
+++ b/banyan/Cargo.toml
@@ -24,7 +24,6 @@ maplit = "1.0"
 derive_more = "0.99"
 anyhow = "1.0"
 rand = "0.7"
-ref-cast = "1.0"
 
 [dev-dependencies]
 hex = "0.4.2"

--- a/banyan/Cargo.toml
+++ b/banyan/Cargo.toml
@@ -31,7 +31,8 @@ tokio = { version = "0.2.20", features = ["full"] }
 reqwest = { version = "0.10.4", features = ["json"] }
 clap = "2.33.1"
 tracing-subscriber = "0.2.5"
-quickcheck = "0.9.2"
-quickcheck_async = "0.1.1"
 env_logger = "0.7.1"
 sha2 = "0.9.1"
+quickcheck = "0.9"
+quickcheck_macros = "0.9"
+quickcheck_async = "0.1.1"

--- a/banyan/src/forest/read.rs
+++ b/banyan/src/forest/read.rs
@@ -154,7 +154,6 @@ where
         Ok(if let Some(link) = &index.link {
             let bytes = self.store.get(&link).await?;
             let children: Vec<_> = deserialize_compressed(&self.index_key(), &bytes)?;
-            // let children = CborZstdArrayRef::new(bytes.as_ref()).items()?;
             Some(Branch::<T>::new(children))
         } else {
             None

--- a/banyan/src/forest/stream.rs
+++ b/banyan/src/forest/stream.rs
@@ -22,7 +22,7 @@ impl<
         roots: BoxStream<'static, T::Link>,
     ) -> impl Stream<Item = anyhow::Result<(u64, T::Key, V)>> + Send {
         self.stream_roots_chunked(query, roots, &|_| ())
-            .map_ok(|chunk| stream::iter(chunk.data.into_iter().map(|x| Ok(x))))
+            .map_ok(|chunk| stream::iter(chunk.data.into_iter().map(Ok)))
             .try_flatten()
     }
 

--- a/banyan/src/lib.rs
+++ b/banyan/src/lib.rs
@@ -64,3 +64,9 @@ mod thread_local_zstd;
 pub mod tree;
 mod util;
 mod zstd_array;
+
+#[cfg(test)]
+extern crate quickcheck;
+#[cfg(test)]
+#[macro_use(quickcheck)]
+extern crate quickcheck_macros;

--- a/banyan/src/lib.rs
+++ b/banyan/src/lib.rs
@@ -60,6 +60,7 @@ pub mod forest;
 pub mod index;
 pub mod query;
 pub mod store;
+mod thread_local_zstd;
 pub mod tree;
 mod util;
 mod zstd_array;

--- a/banyan/src/thread_local_zstd.rs
+++ b/banyan/src/thread_local_zstd.rs
@@ -1,0 +1,62 @@
+//! # ZStd decompressor that uses thread local buffers to prevent allocations
+use std::cell::RefCell;
+use zstd::block::Decompressor;
+
+/// minimum size of the buffer
+const MIN_CAPACITY: usize = 1024 * 16;
+/// max capacity the buffer will grow to.
+const MAX_CAPACITY: usize = 1024 * 1024 * 4;
+
+/// thread-local decompression state
+pub(crate) struct DecompressionState {
+    /// reused zstd decompressor
+    decompressor: Decompressor,
+    /// buffer that can grow up to MAX_CAPACITY
+    buffer: Vec<u8>,
+}
+
+impl DecompressionState {
+    fn new() -> Self {
+        let buffer: Vec<u8> = Vec::with_capacity(1024);
+        Self {
+            decompressor: Decompressor::new(),
+            buffer,
+        }
+    }
+
+    fn decompress(&mut self, data: &[u8]) -> std::io::Result<usize> {
+        let mut cap = MIN_CAPACITY;
+        loop {
+            self.buffer.resize(cap, 0);
+            let res = self
+                .decompressor
+                .decompress_to_buffer(data, &mut self.buffer);
+            if res.is_ok() || cap >= MAX_CAPACITY {
+                return res;
+            } else {
+                cap *= 2;
+            }
+        }
+    }
+
+    fn decompress_and_transform<F, R>(&mut self, compressed: &[u8], f: &mut F) -> std::io::Result<R>
+    where
+        F: FnMut(&[u8]) -> R,
+    {
+        let len = self.decompress(compressed)?;
+        let result = f(&self.buffer[0..len]);
+        self.buffer.truncate(MIN_CAPACITY);
+        self.buffer.shrink_to_fit();
+        Ok(result)
+    }
+}
+
+thread_local!(static DECOMPRESSOR: RefCell<DecompressionState> = RefCell::new(DecompressionState::new()));
+
+/// decompress some data into an internal thread-local buffer, and, on success, applies a transform to the buffer
+pub fn decompress_and_transform<F, R>(compressed: &[u8], f: &mut F) -> std::io::Result<R>
+where
+    F: FnMut(&[u8]) -> R,
+{
+    DECOMPRESSOR.with(|d| d.borrow_mut().decompress_and_transform(compressed, f))
+}

--- a/banyan/src/thread_local_zstd.rs
+++ b/banyan/src/thread_local_zstd.rs
@@ -60,3 +60,19 @@ where
 {
     DECOMPRESSOR.with(|d| d.borrow_mut().decompress_and_transform(compressed, f))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use quickcheck::quickcheck;
+    use std::io::Cursor;
+
+    /// basic test to ensure that the decompress works and properly clears the thread local buffer
+    #[quickcheck]
+    fn thread_local_compression_decompression(data: Vec<u8>) -> anyhow::Result<bool> {
+        let cursor = Cursor::new(&data);
+        let compressed = zstd::encode_all(cursor, 0)?;
+        let decompressed = decompress_and_transform(&compressed, &mut |x| x.to_vec())?;
+        Ok(data == decompressed)
+    }
+}

--- a/banyan/src/zstd_array.rs
+++ b/banyan/src/zstd_array.rs
@@ -1,99 +1,91 @@
 //! Utilities to work with zstd compressed arrays of cbor values
+use crate::thread_local_zstd::decompress_and_transform;
 use anyhow::Result;
-use core::{fmt, ops::Deref};
-use ref_cast::RefCast;
+use core::fmt;
 use serde::{
     de::{DeserializeOwned, IgnoredAny},
     Deserialize, Serialize,
 };
 use std::{
-    io,
     io::{prelude::*, Cursor, Write},
     sync::Arc,
 };
 use tracing::*;
-use zstd::stream::{
-    raw::{Decoder as ZDecoder, Operation, OutBuffer},
-    write::Encoder,
-};
+use zstd::stream::write::Encoder;
 
 /// An array of zstd compressed data
 pub struct ZstdArray {
     data: Arc<[u8]>,
 }
 
-#[derive(RefCast)]
-#[repr(transparent)]
-pub struct ZstdArrayRef([u8]);
+impl From<ZstdArray> for Arc<[u8]> {
+    fn from(value: ZstdArray) -> Self {
+        value.data
+    }
+}
 
-impl ZstdArrayRef {
+impl ZstdArray {
+    pub fn new(data: Arc<[u8]>) -> Self {
+        Self { data }
+    }
+
+    /// create ZStdArray from a single serializable item
+    pub fn single<T: Serialize>(value: T, level: i32) -> Result<Self> {
+        let mut encoder = Encoder::new(Vec::new(), level)?;
+        serde_cbor::to_writer(&mut encoder, &value)?;
+        // call finish to write the zstd frame
+        let data = encoder.finish()?;
+        // box into an arc
+        Ok(Self::new(data.into()))
+    }
+
+    /// create a ZStdArray by filling from an iterator
+    pub fn fill<T: Serialize>(
+        compressed: &[u8],
+        mut from: impl FnMut() -> Option<T>,
+        level: i32,
+        compressed_size: u64,
+    ) -> Result<Self> {
+        let mut encoder = Encoder::new(Vec::new(), level)?;
+        // decompress into the encoder, if necessary
+        if !compressed.is_empty() {
+            // the first ? is to handle the io error from decompress_and_transform, the second to handle the inner io error from write_all
+            decompress_and_transform(compressed, &mut |decompressed| {
+                encoder.write_all(decompressed)
+            })??;
+        }
+        // fill until rough size goal exceeded
+        while (encoder.get_ref().len() as u64) < compressed_size {
+            if let Some(value) = from() {
+                serde_cbor::to_writer(&mut encoder, &value)?;
+            } else {
+                break;
+            }
+        }
+        // call finish to write the zstd frame
+        let data = encoder.finish()?;
+        // box into an arc
+        Ok(Self::new(data.into()))
+    }
+
     /// Get the compressed data
     pub fn compressed(&self) -> &[u8] {
-        &self.0
-    }
-
-    #[allow(dead_code)]
-    fn decompress_into_broken(&self, mut uncompressed: Vec<u8>) -> Result<Vec<u8>> {
-        let data = self.compressed();
-        let mut c = Cursor::new(data);
-        while c.position() < data.len() as u64 {
-            let mut reader = zstd::stream::read::Decoder::new(c.by_ref())?.single_frame();
-            reader.read_to_end(&mut uncompressed)?;
-        }
-        Ok(uncompressed)
-    }
-
-    fn decompress_into(&self, uncompressed: Vec<u8>) -> Result<Vec<u8>> {
-        // let data = self.raw();
-        // let mut writer = zstd::stream::write::Decoder::new(uncompressed.by_ref())?;
-        // writer.write_all(data)?;
-        // writer.flush()?;
-        // Ok(uncompressed)
-        self.decompress_into_lowlevel(uncompressed)
-    }
-
-    #[allow(dead_code)]
-    fn decompress_into_lowlevel(&self, mut uncompressed: Vec<u8>) -> Result<Vec<u8>> {
-        // let mut cipher = (self.mk_cipher)();
-        // cipher.apply_keystream(&mut data);
-        let mut src = zstd::stream::raw::InBuffer::around(&self.0);
-        // todo: thread local buffers that grow dynamically
-        let mut tmp = [0u8; 4096 * 100];
-        let mut decompressor = ZDecoder::new()?;
-        // decompress until input is consumed
-        loop {
-            let mut out = OutBuffer::around(&mut tmp);
-            let _ = decompressor.run(&mut src, &mut out)?;
-            let n = out.pos;
-            uncompressed.extend_from_slice(&tmp[..n]);
-            if src.pos == src.src.len() {
-                break;
-            }
-        }
-        loop {
-            let mut out = OutBuffer::around(&mut tmp);
-            let remaining = decompressor.flush(&mut out)?;
-            let n = out.pos;
-            uncompressed.extend_from_slice(&tmp[..n]);
-            if remaining == 0 {
-                break;
-            }
-        }
-        info!("decompress {} {}", self.0.len(), uncompressed.len());
-        Ok(uncompressed)
+        &self.data
     }
 
     pub fn items<T: DeserializeOwned>(&self) -> Result<Vec<T>> {
         info!("compressed length {}", self.compressed().len());
-        let uncompressed = self.decompress_into(Vec::new())?;
-        info!("uncompressed length {}", uncompressed.len());
-        let mut result = Vec::new();
-        let mut r = Cursor::new(&uncompressed);
-        while r.position() < uncompressed.len() as u64 {
-            let mut deserializer = serde_cbor::Deserializer::from_reader(r.by_ref());
-            result.push(T::deserialize(&mut deserializer)?);
-        }
-        Ok(result)
+
+        decompress_and_transform(self.compressed(), &mut |uncompressed| {
+            info!("uncompressed length {}", uncompressed.len());
+            let mut result = Vec::new();
+            let mut r = Cursor::new(&uncompressed);
+            while r.position() < uncompressed.len() as u64 {
+                let mut deserializer = serde_cbor::Deserializer::from_reader(r.by_ref());
+                result.push(T::deserialize(&mut deserializer)?);
+            }
+            Ok(result)
+        })?
     }
 
     pub fn count(&self) -> Result<u64> {
@@ -104,63 +96,45 @@ impl ZstdArrayRef {
     ///
     /// Other items will be skipped when deserializing, saving some unnecessary work.
     pub fn get<T: DeserializeOwned>(&self, index: u64) -> Result<Option<T>> {
-        let uncompressed = self.decompress_into(Vec::new())?;
-        let mut r = Cursor::new(&uncompressed);
-        let mut remaining = index;
-        while r.position() < uncompressed.len() as u64 {
-            let mut deserializer = serde_cbor::Deserializer::from_reader(r.by_ref());
-            if remaining > 0 {
-                IgnoredAny::deserialize(&mut deserializer)?;
-                remaining -= 1;
-            } else {
-                return Ok(Some(T::deserialize(&mut deserializer)?));
+        decompress_and_transform(self.compressed(), &mut |uncompressed| {
+            let mut r = Cursor::new(&uncompressed);
+            let mut remaining = index;
+            while r.position() < uncompressed.len() as u64 {
+                let mut deserializer = serde_cbor::Deserializer::from_reader(r.by_ref());
+                if remaining > 0 {
+                    IgnoredAny::deserialize(&mut deserializer)?;
+                    remaining -= 1;
+                } else {
+                    return Ok(Some(T::deserialize(&mut deserializer)?));
+                }
             }
-        }
-        Ok(None)
+            Ok(None)
+        })?
     }
 
     /// select the items marked by the iterator and deserialize them into a vec.
     ///
     /// Other items will be skipped when deserializing, saving some unnecessary work.
     pub fn select<T: DeserializeOwned>(&self, take: &[bool]) -> Result<Vec<T>> {
-        let uncompressed = self.decompress_into(Vec::new())?;
-        let mut result: Vec<T> = Vec::new();
-        let mut r = Cursor::new(&uncompressed);
-        let mut i: usize = 0;
-        while r.position() < uncompressed.len() as u64 {
-            if i < take.len() {
-                let mut deserializer = serde_cbor::Deserializer::from_reader(r.by_ref());
-                if take[i] {
-                    result.push(T::deserialize(&mut deserializer)?);
+        decompress_and_transform(self.compressed(), &mut |uncompressed| {
+            let mut result: Vec<T> = Vec::new();
+            let mut r = Cursor::new(&uncompressed);
+            let mut i: usize = 0;
+            while r.position() < uncompressed.len() as u64 {
+                if i < take.len() {
+                    let mut deserializer = serde_cbor::Deserializer::from_reader(r.by_ref());
+                    if take[i] {
+                        result.push(T::deserialize(&mut deserializer)?);
+                    } else {
+                        IgnoredAny::deserialize(&mut deserializer)?;
+                    }
+                    i += 1;
                 } else {
-                    IgnoredAny::deserialize(&mut deserializer)?;
+                    break;
                 }
-                i += 1;
-            } else {
-                break;
             }
-        }
-        Ok(result)
-    }
-}
-
-impl Deref for ZstdArray {
-    type Target = ZstdArrayRef;
-    fn deref(&self) -> &Self::Target {
-        ZstdArrayRef::ref_cast(&self.data)
-    }
-}
-
-impl Deref for ZstdArrayBuilder {
-    type Target = ZstdArrayRef;
-    fn deref(&self) -> &Self::Target {
-        ZstdArrayRef::ref_cast(&self.encoder.get_ref().as_ref())
-    }
-}
-
-impl ZstdArray {
-    pub fn new(data: Arc<[u8]>) -> Self {
-        Self { data }
+            Ok(result)
+        })?
     }
 }
 
@@ -170,135 +144,7 @@ impl fmt::Debug for ZstdArray {
     }
 }
 
-/// An reference of zstd compressed data from either a [ZstdArray](struct.ZstdArray.html) or a [ZstdArrayBuilder](struct.ZstdArrayBuilder.html)
-
-// struct CborIterator<'a, T, P> {
-//     reader: Cursor<&'a [u8]>,
-//     take: P,
-//     _p: PhantomData<T>,
-// }
-
-// impl<'a, T: DeserializeOwned, P: FnMut(usize) -> bool> Iterator for CborIterator<'a, T, P> {
-//     type Item = T;
-//     fn next(&mut self) -> Option<T> {
-//         while self.reader.position() < self.reader.get_ref().len() as u64 {
-//             if self.take() {
-
-//             }
-//         }
-//         None
-//     }
-// }
-
-/// a builder for a [ZstdArray](struct.ZstdArray.html).
-///
-/// The self-contained result of the builder is available as a [ZstdArrayRef](struct.ZstdArrayRef.html) at any time.
-pub struct ZstdArrayBuilder {
-    encoder: zstd::stream::write::Encoder<Vec<u8>>,
-}
-
-impl fmt::Debug for ZstdArrayBuilder {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "ZstdArrayBuilder")
-    }
-}
-
-impl ZstdArrayBuilder {
-    pub fn init(data: &[u8], level: i32) -> Result<Self> {
-        let decompressed = ZstdArrayRef::ref_cast(data).decompress_into(Vec::new())?;
-        let res = Self::new(level)?;
-        let res = res.push_bytes(&decompressed)?;
-        Ok(res)
-    }
-
-    pub fn new(level: i32) -> io::Result<Self> {
-        Ok(Self {
-            encoder: Encoder::new(Vec::new(), level)?,
-        })
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.compressed().is_empty()
-    }
-
-    /// Writes some data and makes sure the zstd encoder state is flushed.
-    ///
-    /// Flushing closes a zstd frame, so pushing individual, small items has some overhead
-    /// comparing to adding multiple items.
-    pub fn push_bytes(mut self, value: &[u8]) -> Result<Self> {
-        self.encoder.write_all(value)?;
-        self.encoder.flush()?;
-        Ok(self)
-    }
-
-    /// Writes some data and makes sure the zstd encoder state is flushed.
-    ///
-    /// Flushing closes a zstd frame, so pushing individual, small items has some overhead
-    /// comparing to adding multiple items.
-    pub fn push<T: Serialize>(mut self, value: &T) -> Result<Self> {
-        serde_cbor::to_writer(&mut self.encoder, value)?;
-        self.encoder.flush()?;
-        Ok(self)
-    }
-
-    /// fill the array from a source, until the compressed size exceeds the given size.
-    ///
-    /// note that the encoder will be flushed just once at the end of the fill op, so the size might be
-    /// significantly above the target size.
-    pub fn fill<T: Serialize>(
-        mut self,
-        mut from: impl FnMut() -> Option<T>,
-        compressed_size: u64,
-    ) -> Result<Self> {
-        while (self.compressed().len() as u64) < compressed_size {
-            if let Some(value) = from() {
-                serde_cbor::to_writer(&mut self.encoder, &value)?;
-            } else {
-                break;
-            }
-        }
-        self.encoder.flush()?;
-        Ok(self)
-    }
-
-    pub fn build(self) -> Result<ZstdArray> {
-        Ok(ZstdArray::new(self.encoder.finish()?.into()))
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn incremental_build() -> Result<()> {
-        let mut w = ZstdArrayBuilder::new(10)?;
-        let mut expected: Vec<u64> = Vec::new();
-        for i in 0u64..10 {
-            w = w.push(&i)?;
-            expected.push(i);
-            println!(
-                "xxx {} {}",
-                w.compressed().len(),
-                hex::encode(w.compressed())
-            );
-            let items: Vec<u64> = w.items()?;
-            assert_eq!(items, expected);
-        }
-        Ok(())
-    }
-
-    #[test]
-    fn read_builder() -> Result<()> {
-        let mut w = ZstdArrayBuilder::new(10)?;
-        let mut expected: Vec<u64> = Vec::new();
-        for i in 0u64..100 {
-            w = w.push(&i)?;
-            expected.push(i);
-            w = ZstdArrayBuilder::init(w.compressed(), 10)?;
-            let items: Vec<u64> = w.items()?;
-            assert_eq!(items, expected);
-        }
-        Ok(())
-    }
 }

--- a/banyan/src/zstd_array.rs
+++ b/banyan/src/zstd_array.rs
@@ -147,4 +147,12 @@ impl fmt::Debug for ZstdArray {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use quickcheck::quickcheck;
+    use std::io::Cursor;
+
+    /// basic test to ensure that the decompress works and properly clears the thread local buffer
+    #[quickcheck]
+    fn fill_roundtrip(data: Vec<Vec<u8>>) -> anyhow::Result<bool> {
+        Ok(true)
+    }
 }

--- a/banyan/tests/build_check.rs
+++ b/banyan/tests/build_check.rs
@@ -105,12 +105,8 @@ where
     I::IntoIter: Send,
 {
     let store = Arc::new(MemStore::new());
-    let forest = Transaction::<TT, u64>::new(
-        store.clone(),
-        store,
-        Config::debug(),
-        Default::default(),
-    );
+    let forest =
+        Transaction::<TT, u64>::new(store.clone(), store, Config::debug(), Default::default());
     let mut tree = Tree::<TT, u64>::empty(forest);
     tree.extend(xs).await?;
     tree.assert_invariants().await?;
@@ -277,12 +273,8 @@ async fn build_get(xs: Vec<(Key, u64)>) -> quickcheck::TestResult {
 async fn build_pack(xss: Vec<Vec<(Key, u64)>>) -> quickcheck::TestResult {
     test(|| async {
         let store = Arc::new(MemStore::new());
-        let forest = Transaction::<TT, u64>::new(
-            store.clone(),
-            store,
-            Config::debug(),
-            Default::default(),
-        );
+        let forest =
+            Transaction::<TT, u64>::new(store.clone(), store, Config::debug(), Default::default());
         let mut tree = Tree::<TT, u64>::empty(forest);
         // flattened xss for reference
         let xs = xss.iter().cloned().flatten().collect::<Vec<_>>();
@@ -308,12 +300,8 @@ async fn build_pack(xss: Vec<Vec<(Key, u64)>>) -> quickcheck::TestResult {
 async fn retain(xss: Vec<Vec<(Key, u64)>>) -> quickcheck::TestResult {
     test(|| async {
         let store = Arc::new(MemStore::new());
-        let forest = Transaction::<TT, u64>::new(
-            store.clone(),
-            store,
-            Config::debug(),
-            Default::default(),
-        );
+        let forest =
+            Transaction::<TT, u64>::new(store.clone(), store, Config::debug(), Default::default());
         let mut tree = Tree::<TT, u64>::empty(forest);
         // flattened xss for reference
         let xs = xss.iter().cloned().flatten().collect::<Vec<_>>();
@@ -344,12 +332,8 @@ async fn filter_test_simple() -> anyhow::Result<()> {
 #[tokio::test]
 async fn stream_test_simple() -> anyhow::Result<()> {
     let store = Arc::new(MemStore::new());
-    let forest = Transaction::<TT, u64>::new(
-        store.clone(),
-        store,
-        Config::debug(),
-        Default::default(),
-    );
+    let forest =
+        Transaction::<TT, u64>::new(store.clone(), store, Config::debug(), Default::default());
     let mut trees = Vec::new();
     for n in 1..=10u64 {
         let mut tree = Tree::<TT, u64>::empty(forest.clone());


### PR DESCRIPTION
also, get rid of ZstdArrayBuilder and the whole ref_cast stuff

performance wise, this will only matter if it is not completely drowned by other allocations, like e.g. lots of individually allocated tags