### PR TITLE
Tree refactor

### DIFF
--- a/banyan-cli/src/main.rs
+++ b/banyan-cli/src/main.rs
@@ -216,8 +216,8 @@ async fn build_tree(
         }
     };
     let mut tree = match base {
-        Some(root) => Tree::<TT, String>::from_link(root, forest.clone()).await?,
-        None => Tree::<TT, String>::empty(forest.clone()),
+        Some(root) => Tree::<TT, String>::from_link(root, &forest).await?,
+        None => Tree::<TT, String>::empty(),
     };
     let mut offset: u64 = 0;
     for _ in 0..batches {
@@ -235,11 +235,11 @@ async fn build_tree(
             })
             .collect::<Vec<_>>();
         if unbalanced {
-            tree.extend_unpacked(v).await?;
-            tree.assert_invariants().await?;
+            tree.extend_unpacked(&forest, v).await?;
+            tree.assert_invariants(&forest).await?;
         } else {
-            tree.extend(v).await?;
-            tree.assert_invariants().await?;
+            tree.extend(&forest, v).await?;
+            tree.assert_invariants(&forest).await?;
         }
     }
     Ok(tree)
@@ -268,8 +268,8 @@ async fn bench_build(
         }
     };
     let mut tree = match base {
-        Some(root) => Tree::<TT, String>::from_link(root, forest.clone()).await?,
-        None => Tree::<TT, String>::empty(forest.clone()),
+        Some(root) => Tree::<TT, String>::from_link(root, &forest).await?,
+        None => Tree::<TT, String>::empty(),
     };
     let mut offset: u64 = 0;
     let data = (0..batches)
@@ -290,11 +290,11 @@ async fn bench_build(
     let t0 = std::time::Instant::now();
     for v in data {
         if unbalanced {
-            tree.extend_unpacked(v).await?;
-            tree.assert_invariants().await?;
+            tree.extend_unpacked(&forest, v).await?;
+            tree.assert_invariants(&forest).await?;
         } else {
-            tree.extend(v).await?;
-            tree.assert_invariants().await?;
+            tree.extend(&forest, v).await?;
+            tree.assert_invariants(&forest).await?;
         }
     }
     let t1 = std::time::Instant::now();
@@ -349,8 +349,8 @@ async fn main() -> Result<()> {
                 .value_of("root")
                 .ok_or_else(|| anyhow!("root must be provided"))?,
         )?;
-        let tree = Tree::<TT, String>::from_link(root, forest).await?;
-        tree.dump().await?;
+        let tree = Tree::<TT, String>::from_link(root, &forest).await?;
+        tree.dump(&forest).await?;
         return Ok(());
     } else if let Some(matches) = matches.subcommand_matches("stream") {
         let root = Sha256Digest::from_str(
@@ -358,8 +358,8 @@ async fn main() -> Result<()> {
                 .value_of("root")
                 .ok_or_else(|| anyhow!("root must be provided"))?,
         )?;
-        let tree = Tree::<TT, String>::from_link(root, forest).await?;
-        let mut stream = tree.stream_filtered(AllQuery).enumerate();
+        let tree = Tree::<TT, String>::from_link(root, &forest).await?;
+        let mut stream = tree.stream_filtered(&forest, AllQuery).enumerate();
         while let Some((i, Ok(v))) = stream.next().await {
             if i % 1000 == 0 {
                 println!("{:?}", v);
@@ -385,26 +385,26 @@ async fn main() -> Result<()> {
             batches, count, unbalanced
         );
         let tree = build_tree(forest.clone(), base, batches, count, unbalanced, 1000).await?;
-        tree.dump().await?;
-        let roots = tree.roots().await?;
+        tree.dump(&forest).await?;
+        let roots = tree.roots(&forest).await?;
         let levels = roots.iter().map(|x| x.level()).collect::<Vec<_>>();
-        let tree2 = Tree::<TT, String>::from_roots(forest, roots).await?;
+        let tree2 = Tree::<TT, String>::from_roots(&forest, roots).await?;
         println!("{:?}", tree);
         println!("{}", tree);
         println!("{:?}", levels);
-        tree2.dump().await?;
+        tree2.dump(&forest).await?;
     } else if let Some(matches) = matches.subcommand_matches("pack") {
         let root = Sha256Digest::from_str(
             matches
                 .value_of("root")
                 .ok_or_else(|| anyhow!("root must be provided"))?,
         )?;
-        let mut tree = Tree::<TT, String>::from_link(root, forest).await?;
-        tree.dump().await?;
-        tree.pack().await?;
-        tree.assert_invariants().await?;
-        assert!(tree.is_packed().await?);
-        tree.dump().await?;
+        let mut tree = Tree::<TT, String>::from_link(root, &forest).await?;
+        tree.dump(&forest).await?;
+        tree.pack(&forest).await?;
+        tree.assert_invariants(&forest).await?;
+        assert!(tree.is_packed(&forest).await?);
+        tree.dump(&forest).await?;
         println!("{:?}", tree);
     } else if let Some(matches) = matches.subcommand_matches("filter") {
         let root = Sha256Digest::from_str(
@@ -418,9 +418,9 @@ async fn main() -> Result<()> {
             .map(|tag| Key::filter_tags(Tags(btreeset! {Tag::new(tag)})))
             .collect::<Vec<_>>();
         let query = DnfQuery(tags).boxed();
-        let tree = Tree::<TT, String>::from_link(root, forest).await?;
-        tree.dump().await?;
-        let mut stream = tree.stream_filtered(query).enumerate();
+        let tree = Tree::<TT, String>::from_link(root, &forest).await?;
+        tree.dump(&forest).await?;
+        let mut stream = tree.stream_filtered(&forest, query).enumerate();
         while let Some((i, Ok(v))) = stream.next().await {
             if i % 1000 == 0 {
                 println!("{:?}", v);
@@ -432,9 +432,9 @@ async fn main() -> Result<()> {
                 .value_of("root")
                 .ok_or_else(|| anyhow!("root must be provided"))?,
         )?;
-        let mut tree = Tree::<TT, String>::from_link(root, forest).await?;
-        tree.repair().await?;
-        tree.dump().await?;
+        let mut tree = Tree::<TT, String>::from_link(root, &forest).await?;
+        tree.repair(&forest).await?;
+        tree.dump(&forest).await?;
         println!("{:?}", tree);
     } else if let Some(matches) = matches.subcommand_matches("forget") {
         let root = Sha256Digest::from_str(
@@ -446,23 +446,25 @@ async fn main() -> Result<()> {
             .value_of("before")
             .ok_or_else(|| anyhow!("required arg before not provided"))?
             .parse()?;
-        let mut tree = Tree::<TT, String>::from_link(root, forest).await?;
-        tree.retain(&OffsetRangeQuery::from(offset..)).await?;
-        tree.dump().await?;
+        let mut tree = Tree::<TT, String>::from_link(root, &forest).await?;
+        tree.retain(&forest, &OffsetRangeQuery::from(offset..))
+            .await?;
+        tree.dump(&forest).await?;
         println!("{:?}", tree);
     } else if let Some(matches) = matches.subcommand_matches("send_stream") {
         let topic = matches
             .value_of("topic")
             .ok_or_else(|| anyhow!("topic must be provided"))?;
         let mut ticks = tokio::time::interval(Duration::from_secs(1));
-        let mut tree = Tree::<TT, String>::empty(forest);
+        let mut tree = Tree::<TT, String>::empty();
         let mut offset = 0;
         while let Some(_) = ticks.next().await {
             let key = Key::single(offset, offset, tags_from_offset(offset));
-            tree.extend_unpacked(Some((key, "xxx".into()))).await?;
+            tree.extend_unpacked(&forest, Some((key, "xxx".into())))
+                .await?;
             if tree.level() > 100 {
                 println!("packing the tree");
-                tree.pack().await?;
+                tree.pack(&forest).await?;
             }
             offset += 1;
             if let Some(cid) = tree.link() {
@@ -505,7 +507,7 @@ async fn main() -> Result<()> {
         let unbalanced = false;
         let (tree, tcreate) = bench_build(forest.clone(), base, batches, count, unbalanced).await?;
         let t0 = std::time::Instant::now();
-        let _values: Vec<_> = tree.collect().await?;
+        let _values: Vec<_> = tree.collect(&forest).await?;
         let t1 = std::time::Instant::now();
         let tcollect = t1 - t0;
         let t0 = std::time::Instant::now();
@@ -513,7 +515,7 @@ async fn main() -> Result<()> {
         let query = DnfQuery(tags).boxed();
         let values: Vec<_> = tree
             .clone()
-            .stream_filtered(query)
+            .stream_filtered(&forest, query)
             .map_ok(|(_, k, v)| (k, v))
             .collect::<Vec<_>>()
             .await;
@@ -524,7 +526,7 @@ async fn main() -> Result<()> {
         let tags = vec![Key::range(0, count / 10, Tags::single("fizzbuzz"))];
         let query = DnfQuery(tags).boxed();
         let values: Vec<_> = tree
-            .stream_filtered(query)
+            .stream_filtered(&forest, query)
             .map_ok(|(_, k, v)| (k, v))
             .collect::<Vec<_>>()
             .await;

--- a/banyan/src/forest/read.rs
+++ b/banyan/src/forest/read.rs
@@ -160,7 +160,7 @@ where
         })
     }
 
-    pub(crate) async fn get(
+    pub(crate) async fn get0(
         &self,
         index: &Index<T>,
         mut offset: u64,
@@ -192,25 +192,25 @@ where
         node: &'a Index<T>,
         offset: u64,
     ) -> FutureResult<'a, Option<(T::Key, V)>> {
-        self.get(node, offset).boxed()
+        self.get0(node, offset).boxed()
     }
 
     /// Convenience method to stream filtered.
     ///
     /// Implemented in terms of stream_filtered_chunked
-    pub(crate) fn stream_filtered<Q: Query<T> + Clone + 'static>(
+    pub(crate) fn stream_filtered0<Q: Query<T> + Clone + 'static>(
         &self,
         offset: u64,
         query: Q,
         index: Index<T>,
     ) -> BoxStream<'static, Result<(u64, T::Key, V)>> {
-        self.stream_filtered_chunked(offset, query, index, &|_| {})
+        self.stream_filtered_chunked0(offset, query, index, &|_| {})
             .map_ok(|chunk| stream::iter(chunk.data).map(Ok))
             .try_flatten()
             .boxed()
     }
 
-    pub(crate) fn stream_filtered_chunked<
+    pub(crate) fn stream_filtered_chunked0<
         Q: Query<T> + Clone + Send + 'static,
         E: Send + 'static,
         F: Fn(IndexRef<T>) -> E + Send + Sync + 'static,
@@ -250,7 +250,12 @@ where
                         move |(is_matching, (child, offset))| {
                             if is_matching {
                                 this.clone()
-                                    .stream_filtered_chunked(offset, query.clone(), child, mk_extra)
+                                    .stream_filtered_chunked0(
+                                        offset,
+                                        query.clone(),
+                                        child,
+                                        mk_extra,
+                                    )
                                     .right_stream()
                             } else {
                                 let placeholder = FilteredChunk {
@@ -273,7 +278,7 @@ where
         .boxed()
     }
 
-    pub(crate) fn stream_filtered_chunked_reverse<
+    pub(crate) fn stream_filtered_chunked_reverse0<
         Q: Query<T> + Clone + Send + 'static,
         E: Send + 'static,
         F: Fn(IndexRef<T>) -> E + Send + Sync + 'static,
@@ -316,7 +321,7 @@ where
                             move |(is_matching, (child, offset))| {
                                 if is_matching {
                                     this.clone()
-                                        .stream_filtered_chunked_reverse(
+                                        .stream_filtered_chunked_reverse0(
                                             offset,
                                             query.clone(),
                                             child,
@@ -344,7 +349,7 @@ where
         Box::pin(s)
     }
 
-    pub(crate) async fn dump(&self, index: &Index<T>, prefix: &str) -> Result<()> {
+    pub(crate) async fn dump0(&self, index: &Index<T>, prefix: &str) -> Result<()> {
         match self.load_node(index).await? {
             NodeInfo::Leaf(index, _) => {
                 println!(
@@ -386,7 +391,7 @@ where
 
     /// recursion helper for dump
     fn dumpr<'a>(&'a self, index: &'a Index<T>, prefix: &'a str) -> FutureResult<'a, ()> {
-        self.dump(index, prefix).boxed()
+        self.dump0(index, prefix).boxed()
     }
 
     pub(crate) async fn roots(&self, index: &Index<T>) -> Result<Vec<Index<T>>> {
@@ -428,7 +433,7 @@ where
         self.roots0(index, level, res).boxed()
     }
 
-    pub(crate) async fn check_invariants(
+    pub(crate) async fn check_invariants0(
         &self,
         index: &Index<T>,
         level: &mut i32,
@@ -490,11 +495,11 @@ where
         level: &'a mut i32,
         msgs: &'a mut Vec<String>,
     ) -> FutureResult<'a, ()> {
-        self.check_invariants(index, level, msgs).boxed()
+        self.check_invariants0(index, level, msgs).boxed()
     }
 
     /// Checks if a node is packed to the left
-    pub(crate) async fn is_packed(&self, index: &Index<T>) -> Result<bool> {
+    pub(crate) async fn is_packed0(&self, index: &Index<T>) -> Result<bool> {
         Ok(
             if let NodeInfo::Branch(index, branch) = self.load_node(index).await? {
                 if index.sealed {
@@ -522,6 +527,6 @@ where
 
     /// Recursion helper for is_packed
     fn is_packedr<'a>(&'a self, index: &'a Index<T>) -> FutureResult<'a, bool> {
-        self.is_packed(index).boxed()
+        self.is_packed0(index).boxed()
     }
 }

--- a/banyan/src/forest/stream.rs
+++ b/banyan/src/forest/stream.rs
@@ -62,7 +62,7 @@ impl<
                 let offset = offset.clone();
                 forest2
                     .clone()
-                    .stream_filtered_chunked(0, query, index, mk_extra)
+                    .stream_filtered_chunked0(0, query, index, mk_extra)
                     .take_while(move |result| {
                         if let Ok(chunk) = result {
                             // update the offset
@@ -108,7 +108,7 @@ impl<
                 let end_offset_ref = end_offset_ref.clone();
                 forest2
                     .clone()
-                    .stream_filtered_chunked_reverse(0, query, index, mk_extra)
+                    .stream_filtered_chunked_reverse0(0, query, index, mk_extra)
                     .take_while(move |result| {
                         if let Ok(chunk) = result {
                             // update the end offset from the start of what we got

--- a/banyan/src/forest/write.rs
+++ b/banyan/src/forest/write.rs
@@ -251,7 +251,7 @@ where
         Ok(node)
     }
 
-    pub(crate) async fn extend_unpacked<I>(
+    pub(crate) async fn extend_unpacked0<I>(
         &self,
         index: Option<&Index<T>>,
         from: I,
@@ -280,7 +280,7 @@ where
     /// extends an existing node with some values
     ///
     /// The result will have the same level as the input. `from` will contain all elements that did not fit.        
-    async fn extend(
+    async fn extend0(
         &self,
         index: &Index<T>,
         from: &mut iter::Peekable<impl Iterator<Item = (T::Key, V)> + Send>,
@@ -328,7 +328,7 @@ where
         node: &'a Index<T>,
         from: &'a mut iter::Peekable<impl Iterator<Item = (T::Key, V)> + Send>,
     ) -> FutureResult<'a, Index<T>> {
-        self.extend(node, from).boxed()
+        self.extend0(node, from).boxed()
     }
 
     /// Performs a single step of simplification on a sequence of sealed roots of descending level
@@ -381,7 +381,7 @@ where
         Ok((self.writer.put(&cbor).await?, cbor.len() as u64))
     }
 
-    pub(crate) async fn retain<Q: Query<T> + Send + Sync>(
+    pub(crate) async fn retain0<Q: Query<T> + Send + Sync>(
         &self,
         offset: u64,
         query: &Q,
@@ -450,10 +450,10 @@ where
         index: &'a Index<T>,
         level: &'a mut i32,
     ) -> FutureResult<'a, Index<T>> {
-        self.retain(offset, query, index, level).boxed()
+        self.retain0(offset, query, index, level).boxed()
     }
 
-    pub(crate) async fn repair(
+    pub(crate) async fn repair0(
         &self,
         index: &Index<T>,
         report: &mut Vec<String>,
@@ -525,7 +525,7 @@ where
         report: &'a mut Vec<String>,
         level: &'a mut i32,
     ) -> FutureResult<'a, Index<T>> {
-        self.repair(index, report, level).boxed()
+        self.repair0(index, report, level).boxed()
     }
 
     /// creates a new forest

--- a/banyan/src/tree.rs
+++ b/banyan/src/tree.rs
@@ -51,6 +51,258 @@ impl<V, T: TreeTypes> Clone for Tree<T, V> {
 }
 
 impl<
+        T: TreeTypes + 'static,
+        V: Serialize + DeserializeOwned + Clone + Send + Sync + Debug + 'static,
+    > Forest<T, V>
+{
+    pub async fn load(&self, link: T::Link) -> Result<Tree<T, V>> {
+        Ok(Tree {
+            root: Some(self.load_branch_from_link(link).await?),
+            _t: PhantomData,
+        })
+    }
+
+    /// dumps the tree structure
+    pub async fn dump(&self, tree: &Tree<T, V>) -> Result<()> {
+        match &tree.root {
+            Some(index) => self.dump0(index, "").await,
+            None => Ok(()),
+        }
+    }
+
+    /// sealed roots of the tree
+    pub async fn tree_roots(&self, tree: &Tree<T, V>) -> Result<Vec<Index<T>>> {
+        match &tree.root {
+            Some(index) => self.roots(index).await,
+            None => Ok(Vec::new()),
+        }
+    }
+
+    pub async fn check_invariants(&self, tree: &Tree<T, V>) -> Result<Vec<String>> {
+        let mut msgs = Vec::new();
+        if let Some(root) = &tree.root {
+            if root.level() == 0 {
+                msgs.push("tree should not have a leaf as direct child.".into());
+            }
+            let mut level = i32::max_value();
+            self.check_invariants0(&root, &mut level, &mut msgs).await?;
+        }
+        Ok(msgs)
+    }
+
+    pub async fn is_packed(&self, tree: &Tree<T, V>) -> Result<bool> {
+        if let Some(root) = &tree.root {
+            self.is_packed0(&root).await
+        } else {
+            Ok(true)
+        }
+    }
+
+    pub async fn assert_invariants(&self, tree: &Tree<T, V>) -> Result<()> {
+        let msgs = tree.check_invariants(self).await?;
+        if !msgs.is_empty() {
+            for msg in msgs {
+                error!("Invariant failed: {}", msg);
+            }
+            panic!("assert_invariants failed");
+        }
+        Ok(())
+    }
+
+    /// Collects all elements from a stream. Might produce an OOM for large streams.
+    pub async fn collect<B: FromIterator<(T::Key, V)>>(&self, tree: &Tree<T, V>) -> Result<B> {
+        let query = AllQuery;
+        let items: Vec<Result<(T::Key, V)>> = self
+            .stream_filtered(tree, query)
+            .map_ok(|(_, k, v)| (k, v))
+            .collect::<Vec<_>>()
+            .await;
+        items.into_iter().collect::<Result<_>>()
+    }
+
+    /// Collects all elements from the given offset. Might produce an OOM for large streams.
+    pub async fn collect_from<B: FromIterator<(T::Key, V)>>(
+        &self,
+        tree: &Tree<T, V>,
+        offset: u64,
+    ) -> Result<B> {
+        let query = OffsetRangeQuery::from(offset..);
+        let items: Vec<Result<(T::Key, V)>> = self
+            .stream_filtered(tree, query)
+            .map_ok(|(_, k, v)| (k, v))
+            .collect::<Vec<_>>()
+            .await;
+        items.into_iter().collect::<Result<_>>()
+    }
+
+    pub fn stream_filtered(
+        &self,
+        tree: &Tree<T, V>,
+        query: impl Query<T> + Clone + 'static,
+    ) -> impl Stream<Item = Result<(u64, T::Key, V)>> + 'static {
+        match &tree.root {
+            Some(index) => self
+                .clone()
+                .stream_filtered0(0, query, index.clone())
+                .left_stream(),
+            None => stream::empty().right_stream(),
+        }
+    }
+
+    pub fn stream_filtered_chunked<Q, E, F>(
+        self,
+        tree: &Tree<T, V>,
+        query: Q,
+        mk_extra: &'static F,
+    ) -> impl Stream<Item = Result<FilteredChunk<T, V, E>>> + 'static
+    where
+        Q: Query<T> + Send + Clone + 'static,
+        E: Send + 'static,
+        F: Fn(IndexRef<T>) -> E + Send + Sync + 'static,
+    {
+        match &tree.root {
+            Some(index) => self
+                .clone()
+                .stream_filtered_chunked0(0, query, index.clone(), mk_extra)
+                .left_stream(),
+            None => stream::empty().right_stream(),
+        }
+    }
+
+    pub fn stream_filtered_chunked_reverse<Q, E, F>(
+        self,
+        tree: &Tree<T, V>,
+        query: Q,
+        mk_extra: &'static F,
+    ) -> impl Stream<Item = Result<FilteredChunk<T, V, E>>> + 'static
+    where
+        Q: Query<T> + Send + Clone + 'static,
+        E: Send + 'static,
+        F: Fn(IndexRef<T>) -> E + Send + Sync + 'static,
+    {
+        match &tree.root {
+            Some(index) => self
+                .clone()
+                .stream_filtered_chunked_reverse0(0, query, index.clone(), mk_extra)
+                .left_stream(),
+            None => stream::empty().right_stream(),
+        }
+    }
+
+    /// element at index
+    pub async fn get(&self, tree: &Tree<T, V>, offset: u64) -> Result<Option<(T::Key, V)>> {
+        Ok(match &tree.root {
+            Some(index) => self.get0(index, offset).await?,
+            None => None,
+        })
+    }
+}
+
+impl<
+        T: TreeTypes + 'static,
+        V: Serialize + DeserializeOwned + Clone + Send + Sync + Debug + 'static,
+    > Transaction<T, V>
+{
+    /// Packs the tree to the left.
+    ///
+    /// For an already packed tree, this is a noop.
+    /// Otherwise, all packed subtrees will be reused without touching them.
+    /// Likewise, sealed subtrees or leafs will be reused if possible.
+    ///
+    /// ![packing illustration](https://ipfs.io/ipfs/QmaEDTjHSdCKyGQ3cFMCf73kE67NvffLA5agquLW5qSEVn/packing.jpg)
+    pub async fn pack(&self, tree: &mut Tree<T, V>) -> Result<()> {
+        let roots = self.tree_roots(tree).await?;
+        let mut filled = Tree::<T, V>::from_roots(&self, roots).await?;
+        let remainder: Vec<_> = self.collect_from(tree, filled.count()).await?;
+        self.extend(&mut filled, remainder).await?;
+        *tree = filled;
+        Ok(())
+    }
+
+    /// append a single element. This is just a shortcut for extend.
+    pub async fn push(&mut self, tree: &mut Tree<T, V>, key: T::Key, value: V) -> Result<()> {
+        self.extend(tree, Some((key, value))).await
+    }
+
+    /// extend the node with the given iterator of key/value pairs
+    ///    
+    /// ![extend illustration](https://ipfs.io/ipfs/QmaEDTjHSdCKyGQ3cFMCf73kE67NvffLA5agquLW5qSEVn/extend.jpg)
+    pub async fn extend<I>(&self, tree: &mut Tree<T, V>, from: I) -> Result<()>
+    where
+        I: IntoIterator<Item = (T::Key, V)>,
+        I::IntoIter: Send,
+    {
+        let mut from = from.into_iter().peekable();
+        if from.peek().is_none() {
+            // nothing to do
+            return Ok(());
+        }
+        tree.root = Some(
+            self.extend_above(tree.root.as_ref(), u32::max_value(), from.by_ref())
+                .await?,
+        );
+        Ok(())
+    }
+
+    /// extend the node with the given iterator of key/value pairs
+    ///
+    /// This variant will not pack the tree, but just create a new tree from the new values and join it
+    /// with the previous tree via an unpacked branch node. Essentially this will produce a degenerate tree
+    /// that resembles a linked list.
+    ///
+    /// To pack a tree, use the pack method.
+    ///    
+    /// ![extend_unpacked illustration](https://ipfs.io/ipfs/QmaEDTjHSdCKyGQ3cFMCf73kE67NvffLA5agquLW5qSEVn/extend_unpacked.jpg)
+    pub async fn extend_unpacked<I>(&self, tree: &mut Tree<T, V>, from: I) -> Result<()>
+    where
+        I: IntoIterator<Item = (T::Key, V)>,
+        I::IntoIter: Send,
+    {
+        tree.root = self.extend_unpacked0(tree.root.as_ref(), from).await?;
+        Ok(())
+    }
+
+    /// Retain just data matching the query
+    ///
+    /// this is done as best effort and will not be precise. E.g. if a chunk of data contains
+    /// just a tiny bit that needs to be retained, the entire chunk will be retained.
+    ///
+    /// from this follows that this is not a suitable method if you want to ensure that the
+    /// non-matching data is completely gone.
+    ///
+    /// note that offsets will not be affected by this. Also, unsealed nodes will not be forgotten
+    /// even if they do not match the query.
+    pub async fn retain<'a, Q: Query<T> + Send + Sync>(
+        &'a self,
+        tree: &mut Tree<T, V>,
+        query: &'a Q,
+    ) -> Result<()> {
+        if let Some(index) = &tree.root {
+            let mut level: i32 = i32::max_value();
+            let res = self.retain0(0, query, index, &mut level).await?;
+            tree.root = Some(res);
+        }
+        Ok(())
+    }
+
+    /// repair a tree by purging parts of the tree that can not be resolved.
+    ///
+    /// produces a report of links that could not be resolved.
+    ///
+    /// Note that this is an emergency measure to recover data if the tree is not completely
+    /// available. It might result in a degenerate tree that can no longer be safely added to,
+    /// especially if there are repaired blocks in the non-packed part.
+    pub async fn repair<'a>(&self, tree: &mut Tree<T, V>) -> Result<Vec<String>> {
+        let mut report = Vec::new();
+        if let Some(index) = &tree.root {
+            let mut level: i32 = i32::max_value();
+            tree.root = Some(self.repair0(index, &mut report, &mut level).await?);
+        }
+        Ok(report)
+    }
+}
+
+impl<
         V: Serialize + DeserializeOwned + Clone + Send + Sync + Debug + 'static,
         T: TreeTypes + 'static,
     > Tree<T, V>
@@ -88,13 +340,13 @@ impl<
     /// dumps the tree structure
     pub async fn dump(&self, txn: &Forest<T, V>) -> Result<()> {
         match &self.root {
-            Some(index) => txn.dump(index, "").await,
+            Some(index) => txn.dump0(index, "").await,
             None => Ok(()),
         }
     }
 
     /// sealed roots of the tree
-    pub async fn roots(&self, txn: &Transaction<T, V>) -> Result<Vec<Index<T>>> {
+    pub async fn roots(&self, txn: &Forest<T, V>) -> Result<Vec<Index<T>>> {
         match &self.root {
             Some(index) => txn.roots(index).await,
             None => Ok(Vec::new()),
@@ -109,7 +361,7 @@ impl<
             }
             let mut level = i32::max_value();
             forest
-                .check_invariants(&root, &mut level, &mut msgs)
+                .check_invariants0(&root, &mut level, &mut msgs)
                 .await?;
         }
         Ok(msgs)
@@ -117,7 +369,7 @@ impl<
 
     pub async fn is_packed(&self, forest: &Forest<T, V>) -> Result<bool> {
         if let Some(root) = &self.root {
-            forest.is_packed(&root).await
+            forest.is_packed0(&root).await
         } else {
             Ok(true)
         }
@@ -215,14 +467,14 @@ impl<
         I: IntoIterator<Item = (T::Key, V)>,
         I::IntoIter: Send,
     {
-        self.root = txn.extend_unpacked(self.root.as_ref(), from).await?;
+        self.root = txn.extend_unpacked0(self.root.as_ref(), from).await?;
         Ok(())
     }
 
     /// element at index
     pub async fn get(&self, forest: &Forest<T, V>, offset: u64) -> Result<Option<(T::Key, V)>> {
         Ok(match &self.root {
-            Some(index) => forest.get(index, offset).await?,
+            Some(index) => forest.get0(index, offset).await?,
             None => None,
         })
     }
@@ -235,7 +487,7 @@ impl<
         match &self.root {
             Some(index) => forest
                 .clone()
-                .stream_filtered(0, query, index.clone())
+                .stream_filtered0(0, query, index.clone())
                 .left_stream(),
             None => stream::empty().right_stream(),
         }
@@ -255,7 +507,7 @@ impl<
         match &self.root {
             Some(index) => forest
                 .clone()
-                .stream_filtered_chunked(0, query, index.clone(), mk_extra)
+                .stream_filtered_chunked0(0, query, index.clone(), mk_extra)
                 .left_stream(),
             None => stream::empty().right_stream(),
         }
@@ -275,7 +527,7 @@ impl<
         match &self.root {
             Some(index) => forest
                 .clone()
-                .stream_filtered_chunked_reverse(0, query, index.clone(), mk_extra)
+                .stream_filtered_chunked_reverse0(0, query, index.clone(), mk_extra)
                 .left_stream(),
             None => stream::empty().right_stream(),
         }
@@ -298,7 +550,7 @@ impl<
     ) -> Result<()> {
         if let Some(index) = &self.root {
             let mut level: i32 = i32::max_value();
-            let res = txn.retain(0, query, index, &mut level).await?;
+            let res = txn.retain0(0, query, index, &mut level).await?;
             self.root = Some(res);
         }
         Ok(())
@@ -315,7 +567,7 @@ impl<
         let mut report = Vec::new();
         if let Some(index) = &self.root {
             let mut level: i32 = i32::max_value();
-            self.root = Some(txn.repair(index, &mut report, &mut level).await?);
+            self.root = Some(txn.repair0(index, &mut report, &mut level).await?);
         }
         Ok(report)
     }


### PR DESCRIPTION
Remove the transaction parameter from the tree

Make it a less OO api. You have to call either forest or transaction with the tree, and get back new trees. Trees are just newtype wrappers for Option<Index<T>>.