### PR TITLE
Separate summary

### DIFF
--- a/banyan-cli/src/tags.rs
+++ b/banyan-cli/src/tags.rs
@@ -330,7 +330,7 @@ impl CompactSeq for KeySeq {
     }
 }
 
-impl HasSummary<Key> for KeySeq {
+impl Summarizable<Key> for KeySeq {
     fn summarize(&self) -> Key {
         let max_time = *self.max_time.iter().max().unwrap();
         let min_time = *self.min_time.iter().min().unwrap();

--- a/banyan-cli/src/tags.rs
+++ b/banyan-cli/src/tags.rs
@@ -331,7 +331,6 @@ impl CompactSeq for KeySeq {
 }
 
 impl HasSummary<Key> for KeySeq {
-
     fn summarize(&self) -> Key {
         let max_time = *self.max_time.iter().max().unwrap();
         let min_time = *self.min_time.iter().min().unwrap();

--- a/banyan-cli/src/tags.rs
+++ b/banyan-cli/src/tags.rs
@@ -92,7 +92,9 @@ impl fmt::Debug for Sha256Digest {
 
 impl TreeTypes for TT {
     type Key = Key;
-    type Seq = KeySeq;
+    type KeySeq = KeySeq;
+    type Summary = Key;
+    type SummarySeq = KeySeq;
     type Link = Sha256Digest;
 }
 
@@ -326,6 +328,9 @@ impl CompactSeq for KeySeq {
     fn len(&self) -> usize {
         self.tags.elements.len()
     }
+}
+
+impl HasSummary<Key> for KeySeq {
 
     fn summarize(&self) -> Key {
         let max_time = *self.max_time.iter().max().unwrap();

--- a/banyan/src/forest/mod.rs
+++ b/banyan/src/forest/mod.rs
@@ -41,17 +41,30 @@ impl<T: TreeTypes> BranchCache<T> {
 /// There might be more types in the future, so this essentially acts as a module for the entire
 /// code base.
 pub trait TreeTypes: Debug + Send + Sync + Clone + 'static {
-    /// key type. This also doubles as the type for a combination (union) of keys
+    /// key type
     type Key: Debug + Eq + Send;
+    /// Type for a summary of keys. In some cases this can be the same type as the key type.
+    type Summary: Debug + Eq + Send;
     /// compact sequence type to be used for indices
-    type Seq: CompactSeq<Item = Self::Key>
+    type KeySeq: CompactSeq<Item = Self::Key>
         + Serialize
         + DeserializeOwned
         + Clone
         + Debug
         + FromIterator<Self::Key>
         + Send
-        + Sync;
+        + Sync
+        + HasSummary<Self::Key>;
+    /// compact sequence type to be used for indices
+    type SummarySeq: CompactSeq<Item = Self::Summary>
+        + Serialize
+        + DeserializeOwned
+        + Clone
+        + Debug
+        + FromIterator<Self::Summary>
+        + Send
+        + Sync
+        + HasSummary<Self::Summary>;
     /// link type to use over block boundaries
     type Link: Display + Debug + Hash + Eq + Clone + Copy + Send + Sync + DagCbor;
 }

--- a/banyan/src/forest/mod.rs
+++ b/banyan/src/forest/mod.rs
@@ -54,7 +54,7 @@ pub trait TreeTypes: Debug + Send + Sync + Clone + 'static {
         + FromIterator<Self::Key>
         + Send
         + Sync
-        + HasSummary<Self::Summary>;
+        + Summarizable<Self::Summary>;
     /// compact sequence type to be used for indices
     type SummarySeq: CompactSeq<Item = Self::Summary>
         + Serialize
@@ -64,7 +64,7 @@ pub trait TreeTypes: Debug + Send + Sync + Clone + 'static {
         + FromIterator<Self::Summary>
         + Send
         + Sync
-        + HasSummary<Self::Summary>;
+        + Summarizable<Self::Summary>;
     /// link type to use over block boundaries
     type Link: Display + Debug + Hash + Eq + Clone + Copy + Send + Sync + DagCbor;
 }

--- a/banyan/src/forest/mod.rs
+++ b/banyan/src/forest/mod.rs
@@ -54,7 +54,7 @@ pub trait TreeTypes: Debug + Send + Sync + Clone + 'static {
         + FromIterator<Self::Key>
         + Send
         + Sync
-        + HasSummary<Self::Key>;
+        + HasSummary<Self::Summary>;
     /// compact sequence type to be used for indices
     type SummarySeq: CompactSeq<Item = Self::Summary>
         + Serialize

--- a/banyan/src/forest/read.rs
+++ b/banyan/src/forest/read.rs
@@ -1,9 +1,5 @@
 use super::{BranchCache, Config, CryptoConfig, FilteredChunk, Forest, TreeTypes};
-use crate::{
-    index::deserialize_compressed, index::zip_with_offset, index::Branch, index::BranchIndex,
-    index::CompactSeq, index::Index, index::IndexRef, index::Leaf, index::LeafIndex,
-    index::NodeInfo, query::Query, store::ReadOnlyStore, util::IpldNode,
-};
+use crate::{index::Branch, index::BranchIndex, index::CompactSeq, index::Index, index::IndexRef, index::Leaf, index::LeafIndex, index::NodeInfo, index::deserialize_compressed, index::{HasSummary, zip_with_offset}, query::Query, store::ReadOnlyStore, util::IpldNode};
 use anyhow::{anyhow, Result};
 use core::fmt::Debug;
 use futures::{prelude::*, stream::BoxStream};

--- a/banyan/src/forest/read.rs
+++ b/banyan/src/forest/read.rs
@@ -1,5 +1,9 @@
 use super::{BranchCache, Config, CryptoConfig, FilteredChunk, Forest, TreeTypes};
-use crate::{index::Branch, index::BranchIndex, index::CompactSeq, index::Index, index::IndexRef, index::Leaf, index::LeafIndex, index::NodeInfo, index::deserialize_compressed, index::{HasSummary, zip_with_offset}, query::Query, store::ReadOnlyStore, util::IpldNode};
+use crate::{
+    index::deserialize_compressed, index::zip_with_offset, index::Branch, index::BranchIndex,
+    index::CompactSeq, index::Index, index::IndexRef, index::Leaf, index::LeafIndex,
+    index::NodeInfo, query::Query, store::ReadOnlyStore, util::IpldNode,
+};
 use anyhow::{anyhow, Result};
 use core::fmt::Debug;
 use futures::{prelude::*, stream::BoxStream};
@@ -81,7 +85,7 @@ where
         let count = children.iter().map(|x| x.count()).sum();
         let value_bytes = children.iter().map(|x| x.value_bytes()).sum();
         let key_bytes = children.iter().map(|x| x.key_bytes()).sum::<u64>() + (bytes.len() as u64);
-        let summaries = children.iter().map(|x| x.data().summarize()).collect();
+        let summaries = children.iter().map(|x| x.summarize()).collect();
         let result = BranchIndex {
             link: Some(link),
             level,
@@ -459,7 +463,7 @@ where
                     }
                 }
                 for (child, summary) in branch.children.iter().zip(index.summaries()) {
-                    let child_summary = child.data().summarize();
+                    let child_summary = child.summarize();
                     check!(child_summary == summary);
                 }
                 let branch_sealed = self.config.branch_sealed(&branch.children, index.level);

--- a/banyan/src/forest/write.rs
+++ b/banyan/src/forest/write.rs
@@ -1,10 +1,4 @@
-use crate::{
-    forest::{BranchResult, Config, CreateMode, Forest, Transaction, TreeTypes},
-    index::zip_with_offset_ref,
-    store::{BlockWriter, ReadOnlyStore},
-    util::IpldNode,
-    zstd_array::ZstdArray,
-};
+use crate::{forest::{BranchResult, Config, CreateMode, Forest, Transaction, TreeTypes}, index::{HasSummary, zip_with_offset_ref}, store::{BlockWriter, ReadOnlyStore}, util::IpldNode, zstd_array::ZstdArray};
 use crate::{
     index::serialize_compressed,
     index::BranchIndex,
@@ -52,7 +46,7 @@ where
     fn extend_leaf(
         &self,
         compressed: &[u8],
-        keys: Option<T::Seq>,
+        keys: Option<T::KeySeq>,
         from: &mut iter::Peekable<impl Iterator<Item = (T::Key, V)>>,
     ) -> Result<LeafIndex<T>> {
         assert!(from.peek().is_some());
@@ -73,7 +67,7 @@ where
             self.config().target_leaf_size,
         )?;
         let leaf = Leaf::new(data.into());
-        let keys = keys.into_iter().collect::<T::Seq>();
+        let keys = keys.into_iter().collect::<T::KeySeq>();
         // encrypt leaf
         let mut tmp: Vec<u8> = Vec::with_capacity(leaf.as_ref().compressed().len() + 24);
         let nonce = self.random_nonce();
@@ -189,7 +183,7 @@ where
             .collect::<Vec<_>>();
         let value_bytes = children.iter().map(|x| x.value_bytes()).sum();
         let sealed = self.config.branch_sealed(&children, level);
-        let summaries: T::Seq = summaries.into_iter().collect();
+        let summaries: T::KeySeq = summaries.into_iter().collect();
         let (link, encoded_children_len) = self.persist_branch(&children)?;
         let key_bytes = children.iter().map(|x| x.key_bytes()).sum::<u64>() + encoded_children_len;
         Ok(BranchIndex {

--- a/banyan/src/forest/write.rs
+++ b/banyan/src/forest/write.rs
@@ -1,4 +1,10 @@
-use crate::{forest::{BranchResult, Config, CreateMode, Forest, Transaction, TreeTypes}, index::{HasSummary, zip_with_offset_ref}, store::{BlockWriter, ReadOnlyStore}, util::IpldNode, zstd_array::ZstdArray};
+use crate::{
+    forest::{BranchResult, Config, CreateMode, Forest, Transaction, TreeTypes},
+    index::zip_with_offset_ref,
+    store::{BlockWriter, ReadOnlyStore},
+    util::IpldNode,
+    zstd_array::ZstdArray,
+};
 use crate::{
     index::serialize_compressed,
     index::BranchIndex,
@@ -123,11 +129,11 @@ where
         }
         let mut summaries = children
             .iter()
-            .map(|child| child.data().summarize())
+            .map(|child| child.summarize())
             .collect::<Vec<_>>();
         while from.peek().is_some() && ((children.len() as u64) < self.config().max_branch_count) {
             let child = self.fill_node(level - 1, from)?;
-            let summary = child.data().summarize();
+            let summary = child.summarize();
             summaries.push(summary);
             children.push(child);
         }
@@ -179,11 +185,11 @@ where
         let count = children.iter().map(|x| x.count()).sum();
         let summaries = children
             .iter()
-            .map(|child| child.data().summarize())
+            .map(|child| child.summarize())
             .collect::<Vec<_>>();
         let value_bytes = children.iter().map(|x| x.value_bytes()).sum();
         let sealed = self.config.branch_sealed(&children, level);
-        let summaries: T::KeySeq = summaries.into_iter().collect();
+        let summaries: T::SummarySeq = summaries.into_iter().collect();
         let (link, encoded_children_len) = self.persist_branch(&children)?;
         let key_bytes = children.iter().map(|x| x.key_bytes()).sum::<u64>() + encoded_children_len;
         Ok(BranchIndex {

--- a/banyan/src/index.rs
+++ b/banyan/src/index.rs
@@ -49,7 +49,7 @@ use salsa20::{
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::{collections::BTreeMap, convert::From, sync::Arc};
 
-pub trait HasSummary<T> {
+pub trait Summarizable<T> {
     fn summarize(&self) -> T;
 }
 

--- a/banyan/src/index.rs
+++ b/banyan/src/index.rs
@@ -49,6 +49,7 @@ use salsa20::{
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::{collections::BTreeMap, convert::From, sync::Arc};
 
+/// An object that can compute a summary of type T of itself
 pub trait Summarizable<T> {
     fn summarize(&self) -> T;
 }
@@ -102,7 +103,7 @@ pub trait CompactSeq: Serialize + DeserializeOwned {
 pub struct LeafIndex<T: TreeTypes> {
     // block is sealed
     pub sealed: bool,
-    // link to the block
+    // link to the block containing the values
     pub link: Option<T::Link>,
     /// A sequence of keys with the same number of values as the data block the link points to.
     pub keys: T::KeySeq,
@@ -143,9 +144,9 @@ pub struct BranchIndex<T: TreeTypes> {
     pub link: Option<T::Link>,
     // extra data
     pub summaries: T::SummarySeq,
-    // serialized size of the children
+    // accumulated serialized size of all values in this tree
     pub value_bytes: u64,
-    // serialized size of the data
+    // accumulated serialized size of all keys and summaries in this tree
     pub key_bytes: u64,
 }
 

--- a/banyan/tests/build_check.rs
+++ b/banyan/tests/build_check.rs
@@ -1,7 +1,4 @@
-use banyan::{
-    forest::{BranchCache, CryptoConfig, Forest},
-    index::CompactSeq,
-};
+use banyan::{forest::{BranchCache, CryptoConfig, Forest}, index::{CompactSeq, HasSummary}};
 use banyan::{
     forest::{Config, Transaction, TreeTypes},
     memstore::MemStore,
@@ -36,6 +33,9 @@ impl CompactSeq for KeySeq {
     fn len(&self) -> usize {
         self.0.len()
     }
+}
+
+impl HasSummary<Key> for KeySeq {
     fn summarize(&self) -> Key {
         let mut res = self.0[0].clone();
         for i in 1..self.0.len() {
@@ -53,7 +53,9 @@ impl FromIterator<Key> for KeySeq {
 
 impl TreeTypes for TT {
     type Key = Key;
-    type Seq = KeySeq;
+    type KeySeq = KeySeq;
+    type Summary = Key;
+    type SummarySeq = KeySeq;
     type Link = Sha256Digest;
 }
 

--- a/banyan/tests/build_check.rs
+++ b/banyan/tests/build_check.rs
@@ -1,4 +1,7 @@
-use banyan::{forest::{BranchCache, CryptoConfig, Forest}, index::{CompactSeq, HasSummary}};
+use banyan::{
+    forest::{BranchCache, CryptoConfig, Forest},
+    index::{CompactSeq, HasSummary},
+};
 use banyan::{
     forest::{Config, Transaction, TreeTypes},
     memstore::MemStore,

--- a/banyan/tests/build_check.rs
+++ b/banyan/tests/build_check.rs
@@ -1,6 +1,6 @@
 use banyan::{
     forest::{BranchCache, CryptoConfig, Forest},
-    index::{CompactSeq, HasSummary},
+    index::{CompactSeq, Summarizable},
 };
 use banyan::{
     forest::{Config, Transaction, TreeTypes},
@@ -38,7 +38,7 @@ impl CompactSeq for KeySeq {
     }
 }
 
-impl HasSummary<Key> for KeySeq {
+impl Summarizable<Key> for KeySeq {
     fn summarize(&self) -> Key {
         let mut res = self.0[0].clone();
         for i in 1..self.0.len() {


### PR DESCRIPTION
This started as an experiment, but it works so well that I have now graduated it to a normal PR.

Note that if you don't want a separate summary type, you can always do that as well, by just using the same type for both in the TreeTypes impl. That is what I do in the tests.