### PR TITLE
Make sure to produce placeholders…

### DIFF
--- a/banyan/src/tree.rs
+++ b/banyan/src/tree.rs
@@ -220,6 +220,10 @@ impl<
     }
 
     /// element at index
+    ///
+    /// returns Ok(None) when offset is larger than count, or when hitting a purged
+    /// part of the tree. Returns an error when part of the tree should be there, but could
+    /// not be read.
     pub fn get(&self, tree: &Tree<T>, offset: u64) -> Result<Option<(T::Key, V)>> {
         Ok(match &tree.root {
             Some(index) => self.get0(index, offset)?,


### PR DESCRIPTION
even when skipping purged leafs or branches