### PR TITLE
Banyan-cli: Some :heart:, graphviz output, clippy

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,7 +16,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: fmt 
+      run: cargo fmt --all -- --check
+    - name: clippy 
+      run: cargo --locked clippy --all-targets -- -D warnings
     - name: Build
-      run: cargo build --verbose
+      run: cargo build --locked --verbose
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --all-features --locked --verbose

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,9 +53,9 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "async-trait"
-version = "0.1.42"
+version = "0.1.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d3a45e77e34375a7923b1e8febb049bb011f064714a8e17a1a616fef01da13d"
+checksum = "36ea56748e10732c49404c153638a15ec3d6211ec5ff35d9bb20e13b93576adf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -91,7 +91,7 @@ dependencies = [
  "futures",
  "generic-array",
  "hex",
- "libipld 0.11.0",
+ "libipld",
  "lru",
  "maplit",
  "multihash",
@@ -121,7 +121,7 @@ dependencies = [
  "hex",
  "ipfs-sqlite-block-store",
  "jemallocator",
- "libipld 0.11.0",
+ "libipld",
  "lru",
  "maplit",
  "multihash",
@@ -215,15 +215,15 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "bumpalo"
-version = "3.6.0"
+version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099e596ef14349721d9016f6b80dd3419ea1bf289ab9b44df8e4dfd3a005d5d9"
+checksum = "63396b8a4b9de3f4fdfb320ab6080762242f66a8ef174c49d8e19b674db4cdbe"
 
 [[package]]
 name = "byteorder"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
@@ -243,9 +243,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.66"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
+checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
 dependencies = [
  "jobserver",
 ]
@@ -271,15 +271,14 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits",
- "time",
  "winapi",
 ]
 
 [[package]]
 name = "cid"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d88f30b1e74e7063df5711496f3ee6e74a9735d62062242d70cddf77717f18e"
+checksum = "ff0e3bc0b6446b3f9663c1a6aba6ef06c5aeaa1bc92bd18077be337198ab9768"
 dependencies = [
  "multibase 0.8.0",
  "multihash",
@@ -395,9 +394,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26ecb66b4bdca6c1409b40fb255eefc2bd4f6d135dab3c3124f80ffa2a9661e"
+checksum = "17392a012ea30ef05a610aa97dfb49496e71c9f676b27879922ea5bdf60d9d3f"
 dependencies = [
  "atty",
  "humantime",
@@ -432,9 +431,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ece68d15c92e84fa4f19d3780f1294e5ca82a78a6d515f1efaabcc144688be00"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
 dependencies = [
  "matches",
  "percent-encoding",
@@ -448,9 +447,9 @@ checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
 
 [[package]]
 name = "futures"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9052a1a50244d8d5aa9bf55cbc2fb6f357c86cc52e46c62ed390a7180cf150"
+checksum = "7f55667319111d593ba876406af7c409c0ebb44dc4be6132a783ccf163ea14c1"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -463,9 +462,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2d31b7ec7efab6eefc7c57233bb10b847986139d88cc2f5a02a1ae6871a1846"
+checksum = "8c2dd2df839b57db9ab69c2c9d8f3e8c81984781937fe2807dc6dcf3b2ad2939"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -473,15 +472,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79e5145dde8da7d1b3892dad07a9c98fc04bc39892b1ecc9692cf53e2b780a65"
+checksum = "15496a72fabf0e62bdc3df11a59a3787429221dd0710ba8ef163d6f7a9112c94"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9e59fdc009a4b3096bf94f740a0f2424c082521f20a9b08c5c07c48d90fd9b9"
+checksum = "891a4b7b96d84d5940084b2a37632dd65deeae662c114ceaa2c879629c9c0ad1"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -491,15 +490,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28be053525281ad8259d47e4de5de657b25e7bac113458555bb4b70bc6870500"
+checksum = "d71c2c65c57704c32f5241c1223167c2c3294fd34ac020c807ddbe6db287ba59"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c287d25add322d9f9abdcdc5927ca398917996600182178774032e9f8258fedd"
+checksum = "ea405816a5139fb39af82c2beb921d52143f556038378d6db21183a5c37fbfb7"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
@@ -509,24 +508,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf5c69029bda2e743fddd0582d1083951d65cc9539aebf8812f36c3491342d6"
+checksum = "85754d98985841b7d4f5e8e6fbfa4a4ac847916893ec511a2917ccd8525b8bb3"
 
 [[package]]
 name = "futures-task"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13de07eb8ea81ae445aca7b69f5f7bf15d7bf4912d8ca37d6645c77ae8a58d86"
-dependencies = [
- "once_cell",
-]
+checksum = "fa189ef211c15ee602667a6fcfe1c1fd9e07d42250d2156382820fba33c9df80"
 
 [[package]]
 name = "futures-util"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632a8cd0f2a4b3fdea1657f08bde063848c3bd00f9bbf6e256b8be78802e624b"
+checksum = "1812c7ab8aedf8d6f2701a43e1243acdbcc2b36ab26e2ad421eb99ac963d96d1"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -564,16 +560,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "glob"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
-
-[[package]]
 name = "h2"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b67e66362108efccd8ac053abafc8b7a8d86a37e6e48fc4f6f7485eb5e9e6a5"
+checksum = "d832b01df74254fe364568d6ddc294443f61cbec82816b60904303af87efae78"
 dependencies = [
  "bytes",
  "fnv",
@@ -586,7 +576,6 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
- "tracing-futures",
 ]
 
 [[package]]
@@ -627,9 +616,9 @@ dependencies = [
 
 [[package]]
 name = "hex"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -686,7 +675,7 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project 1.0.5",
+ "pin-project",
  "socket2",
  "tokio",
  "tower-service",
@@ -696,9 +685,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de910d521f7cc3135c4de8db1cb910e0b5ed1dc6f57c381cd07e8e661ce10094"
+checksum = "89829a5d69c23d348314a7ac337fe39173b61149a9864deabd260983aed48c21"
 dependencies = [
  "matches",
  "unicode-bidi",
@@ -707,9 +696,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb1fa934250de4de8aef298d81c729a7d33d8c239daa3a7575e6b92bfc7313b"
+checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -726,15 +715,15 @@ dependencies = [
 
 [[package]]
 name = "ipfs-sqlite-block-store"
-version = "0.1.12"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0347b794584ed068384126d5be13f6161288aceb59e6fa35bfffdc0b65f5da7d"
+checksum = "3a2c7e40f8ba6bbaaa8c6c5e1f131ed5275b7efa5f5ddaafdc667472f1142f25"
 dependencies = [
  "anyhow",
  "derive_more",
  "fnv",
  "futures",
- "libipld 0.10.0",
+ "libipld",
  "parking_lot",
  "rusqlite",
  "tracing",
@@ -793,9 +782,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.47"
+version = "0.3.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cfb73131c35423a367daf8cbd24100af0d077668c8c2943f0e7dd775fef0f65"
+checksum = "dc9f84f9b115ce7843d60706df1422a916680bfdfcbdb0447c5614ff9d7e4d78"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -814,26 +803,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.86"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7282d924be3275cec7f6756ff4121987bc6481325397dde6ba3e7802b1a8b1c"
-
-[[package]]
-name = "libipld"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "502662e0fa70757c025b8899b1a738f42fa172e83515e8415a78395dca5b6042"
-dependencies = [
- "async-trait",
- "cached",
- "fnv",
- "libipld-core 0.10.0",
- "libipld-macro 0.10.0",
- "log",
- "multihash",
- "parking_lot",
- "thiserror",
-]
+checksum = "03b07a082330a35e43f63177cc01689da34fbffa0105e1246cf0311472cac73a"
 
 [[package]]
 name = "libipld"
@@ -846,9 +818,9 @@ dependencies = [
  "fnv",
  "libipld-cbor",
  "libipld-cbor-derive",
- "libipld-core 0.11.0",
+ "libipld-core",
  "libipld-json",
- "libipld-macro 0.11.0",
+ "libipld-macro",
  "libipld-pb",
  "log",
  "multihash",
@@ -858,21 +830,21 @@ dependencies = [
 
 [[package]]
 name = "libipld-cbor"
-version = "0.11.0"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf8b3d0ce83f18d7b84b81b8e01ba5398895b89e3d5e14d643252821f85a23f"
+checksum = "d0786a9762c8f187d5671c8fb4a30300f00ee867553c7f136e384bf5a3afb64f"
 dependencies = [
  "byteorder",
- "libipld-core 0.11.0",
+ "libipld-core",
  "thiserror",
  "unicode-normalization",
 ]
 
 [[package]]
 name = "libipld-cbor-derive"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed36af388299bc436f0a49014679b1e81d64757b4bb3413431695e4aea01d928"
+checksum = "0f676e94329033adb8cbf3e8a64af60a4f5d5724e291a72f5766b5bfb9ca4b6a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -882,22 +854,9 @@ dependencies = [
 
 [[package]]
 name = "libipld-core"
-version = "0.10.0"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb4c6117e05152bdb8bf1b47b1ebaf22f067a2b8bb99af66886d05d9d8ae0bd8"
-dependencies = [
- "anyhow",
- "cid",
- "multibase 0.9.1",
- "multihash",
- "thiserror",
-]
-
-[[package]]
-name = "libipld-core"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b7616cca1ef5ce28f2ce136413782785bb53c3c497e19b78ed76bb49c3af881"
+checksum = "11f5bf4f0b05d9e7b752b481bcbb8c7e6f6ab403b655ac09e9e71b6febc1e67f"
 dependencies = [
  "anyhow",
  "cid",
@@ -908,24 +867,15 @@ dependencies = [
 
 [[package]]
 name = "libipld-json"
-version = "0.11.0"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6cdb328764e3da87c561a00b5ca8706b440396155c464b0a11a99eca55c15a6"
+checksum = "440c519cdc397b6c091f18548a71df06195a28f2d47e5cb51d1c20d744fde90a"
 dependencies = [
  "base64",
- "libipld-core 0.11.0",
+ "libipld-core",
  "multihash",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "libipld-macro"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e726ab1b1e58d285964711c17cff6e678c2b2d80e784f487252c81b35438546"
-dependencies = [
- "libipld-core 0.10.0",
 ]
 
 [[package]]
@@ -934,16 +884,16 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a2bdd797b0abb80a52c0b215d8721e31c4162216a7930f41af70517f0ed5193"
 dependencies = [
- "libipld-core 0.11.0",
+ "libipld-core",
 ]
 
 [[package]]
 name = "libipld-pb"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f74b8c1e49e72e207e317785c61de7c105e111f805b7aaef6de4adb5f894bc"
+checksum = "65bafd670ca677df2d1c093b4bd47013876926215d980586fe95eaa9a1486fd5"
 dependencies = [
- "libipld-core 0.11.0",
+ "libipld-core",
  "prost",
  "prost-build",
  "thiserror",
@@ -980,9 +930,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe2382d8ed3918ea4ba70d98d5b74e47a168e0331965f3f17cdbc748bdebc5a3"
+checksum = "1f374d42cdfc1d7dbf3d3dec28afab2eb97ffbf43a3234d795b5986dbf4b90ba"
 dependencies = [
  "hashbrown",
 ]
@@ -1032,9 +982,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.7"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e50ae3f04d169fcc9bde0b547d1c205219b7157e07ded9c5aff03e0637cb3ed7"
+checksum = "a5dede4e2065b3842b8b0af444119f3aa331cc7cc2dd20388bfb0f5d5a38823a"
 dependencies = [
  "libc",
  "log",
@@ -1152,9 +1102,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.5.2"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
+checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
 
 [[package]]
 name = "opaque-debug"
@@ -1175,14 +1125,14 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ccb628cad4f84851442432c60ad8e1f607e29752d0bf072cbd0baf28aa34272"
+checksum = "fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018"
 dependencies = [
  "cfg-if 1.0.0",
  "instant",
  "libc",
- "redox_syscall 0.1.57",
+ "redox_syscall",
  "smallvec",
  "winapi",
 ]
@@ -1205,31 +1155,11 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffbc8e94b38ea3d2d8ba92aea2983b503cd75d0888d75b86bb37970b5698e15"
-dependencies = [
- "pin-project-internal 0.4.27",
-]
-
-[[package]]
-name = "pin-project"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96fa8ebb90271c4477f144354485b8068bd8f6b78b428b01ba892ca26caf0b63"
 dependencies = [
- "pin-project-internal 1.0.5",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "0.4.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65ad2ae56b6abe3a1ee25f15ee605bacadb9a764edaba9c2bf4103800d4a1895"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "pin-project-internal",
 ]
 
 [[package]]
@@ -1245,9 +1175,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.4"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439697af366c49a6d0a010c56a0d97685bc140ce0d377b13a2ea2aa42d64a827"
+checksum = "dc0e1f259c92177c30a4c9d177246edd0a3568b25756a977d0632cf8fa37e905"
 
 [[package]]
 name = "pin-utils"
@@ -1406,9 +1336,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "991431c3519a3f36861882da93630ce66b52918dcf1b8e2fd66b397fc96f28df"
+checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
 ]
@@ -1437,9 +1367,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c026d7df8b298d90ccbbc5190bd04d85e159eaf5576caeacf8741da93ccbd2e5"
+checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
 dependencies = [
  "getrandom",
 ]
@@ -1455,15 +1385,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.57"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
-
-[[package]]
-name = "redox_syscall"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ec8ca9416c5ea37062b502703cd7fcb207736bc294f6e0cf367ac6fc234570"
+checksum = "94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9"
 dependencies = [
  "bitflags",
 ]
@@ -1513,9 +1437,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.0"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd281b1030aa675fb90aa994d07187645bb3c8fc756ca766e7c3070b439de9de"
+checksum = "bf12057f289428dbf5c591c74bf10392e4a8003f993405a902f20117019022d4"
 dependencies = [
  "base64",
  "bytes",
@@ -1621,18 +1545,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.123"
+version = "1.0.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d5161132722baa40d802cc70b15262b98258453e85e5d1d365c757c73869ae"
+checksum = "bd761ff957cb2a45fbb9ab3da6512de9de55872866160b23c25f1a841e99d29f"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.123"
+version = "1.0.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9391c295d64fc0abb2c556bad848f33cb8296276b1ad2677d1ae1ace4f258f31"
+checksum = "1800f7693e94e186f5e25a28291ae1570da908aff7d97a095dec1e56ff99069b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1641,9 +1565,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.62"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea1c6153794552ea7cf7cf63b1231a25de00ec90db326ba6264440fa08e31486"
+checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
 dependencies = [
  "itoa",
  "ryu",
@@ -1787,9 +1711,9 @@ checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 
 [[package]]
 name = "syn"
-version = "1.0.60"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
+checksum = "8fd9bc7ccc2688b3344c2f48b9b546648b25ce0b20fc717ee7fa7981a8ca9717"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1817,7 +1741,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "rand",
- "redox_syscall 0.2.4",
+ "redox_syscall",
  "remove_dir_all",
  "winapi",
 ]
@@ -1842,18 +1766,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76cc616c6abf8c8928e2fdcc0dbfab37175edd8fb49a4641066ad1364fdab146"
+checksum = "e0f4a65597094d4483ddaed134f409b2cb7c1beccf25201a9f73c719254fa98e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be73a2caec27583d0046ef3796c3794f868a5bc813db689eed00c7631275cd1"
+checksum = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1867,16 +1791,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
 dependencies = [
  "once_cell",
-]
-
-[[package]]
-name = "time"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
-dependencies = [
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -1896,9 +1810,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8190d04c665ea9e6b6a0dc45523ade572c088d2e6566244c1122671dbf4ae3a"
+checksum = "8d56477f6ed99e10225f38f9f75f872f29b8b8bd8c0b946f63345bb144e9eeda"
 dependencies = [
  "autocfg",
  "bytes",
@@ -1927,9 +1841,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebb7cb2f00c5ae8df755b252306272cd1790d39728363936e01827e11f0b017b"
+checksum = "ec31e5cc6b46e653cf57762f36f71d5e6386391d88a72fd6db4508f8f676fb29"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1956,9 +1870,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.23"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d40a22fd029e33300d8d89a5cc8ffce18bb7c587662f54629e94c9de5487f3"
+checksum = "01ebdc2bb4498ab1ab5f5b73c5803825e60199229ccba0698170e3be0e7f959f"
 dependencies = [
  "cfg-if 1.0.0",
  "pin-project-lite",
@@ -1968,9 +1882,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43f080ea7e4107844ef4766459426fa2d5c1ada2e47edba05dc7fa99d9629f47"
+checksum = "a8a9bd1db7706f2373a190b0d067146caa39350c486f3d455b0e33b431f94c07"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1987,20 +1901,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-futures"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab7bb6f14721aa00656086e9335d363c5c8747bae02ebe32ea2c7dece5689b4c"
-dependencies = [
- "pin-project 0.4.27",
- "tracing",
-]
-
-[[package]]
 name = "tracing-log"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e0f8c7178e13481ff6765bd169b33e8d554c5d2bbede5e32c356194be02b9b9"
+checksum = "a6923477a48e41c1951f1999ef8bb5a3023eb723ceadafe78ffb65dc366761e3"
 dependencies = [
  "lazy_static",
  "log",
@@ -2019,9 +1923,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1fa8f0c8f4c594e4fc9debc1990deab13238077271ba84dd853d54902ee3401"
+checksum = "8ab8966ac3ca27126141f7999361cc97dd6fb4b71da04c02044fa9045d98bb96"
 dependencies = [
  "ansi_term 0.12.1",
  "chrono",
@@ -2110,9 +2014,9 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5909f2b0817350449ed73e8bcd81c8c3c8d9a7a5d8acba4b27db277f1868976e"
+checksum = "9ccd964113622c8e9322cfac19eb1004a07e636c545f325da085d5cdde6f1f8b"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -2168,9 +2072,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.70"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55c0f7123de74f0dab9b7d00fd614e7b19349cd1e2f5252bbe9b1754b59433be"
+checksum = "7ee1280240b7c461d6a0071313e08f34a60b0365f14260362e5a2b17d1d31aa7"
 dependencies = [
  "cfg-if 1.0.0",
  "serde",
@@ -2180,9 +2084,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.70"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bc45447f0d4573f3d65720f636bbcc3dd6ce920ed704670118650bcd47764c7"
+checksum = "5b7d8b6942b8bb3a9b0e73fc79b98095a27de6fa247615e59d096754a3bc2aa8"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -2195,9 +2099,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.20"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3de431a2910c86679c34283a33f66f4e4abd7e0aec27b6669060148872aadf94"
+checksum = "8e67a5806118af01f0d9045915676b22aaebecf4178ae7021bc171dab0b897ab"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -2207,9 +2111,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.70"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b8853882eef39593ad4174dd26fc9865a64e84026d223f63bb2c42affcbba2c"
+checksum = "e5ac38da8ef716661f0f36c0d8320b89028efe10c7c0afde65baffb496ce0d3b"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2217,9 +2121,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.70"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4133b5e7f2a531fa413b3a1695e925038a05a71cf67e87dafa295cb645a01385"
+checksum = "cc053ec74d454df287b9374ee8abb36ffd5acb95ba87da3ba5b7d3fe20eb401e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2230,15 +2134,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.70"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd4945e4943ae02d15c13962b38a5b1e81eadd4b71214eee75af64a4d6a4fd64"
+checksum = "7d6f8ec44822dd71f5f221a5847fb34acd9060535c1211b70a05844c0f6383b1"
 
 [[package]]
 name = "web-sys"
-version = "0.3.47"
+version = "0.3.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c40dc691fc48003eba817c38da7113c15698142da971298003cac3ef175680b3"
+checksum = "ec600b26223b2948cedfde2a0aa6756dcf1fef616f43d7b3097aaf53a6c4d92b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2306,18 +2210,18 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.6.0+zstd.1.4.8"
+version = "0.6.1+zstd.1.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e44664feba7f2f1a9f300c1f6157f2d1bfc3c15c6f3cf4beabf3f5abe9c237"
+checksum = "5de55e77f798f205d8561b8fe2ef57abfb6e0ff2abe7fd3c089e119cdb5631a3"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "3.0.0+zstd.1.4.8"
+version = "3.0.1+zstd.1.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9447afcd795693ad59918c7bbffe42fdd6e467d708f3537e3dc14dc598c573f"
+checksum = "1387cabcd938127b30ce78c4bf00b30387dddf704e3f0881dbc4ff62b5566f8c"
 dependencies = [
  "libc",
  "zstd-sys",
@@ -2325,12 +2229,10 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "1.4.19+zstd.1.4.8"
+version = "1.4.20+zstd.1.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec24a9273d24437afb8e71b16f3d9a5d569193cccdb7896213b59f552f387674"
+checksum = "ebd5b733d7cf2d9447e2c3e76a5589b4f5e5ae065c22a2bc0b023cbc331b6c8e"
 dependencies = [
  "cc",
- "glob",
- "itertools",
  "libc",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,6 +116,7 @@ dependencies = [
  "banyan",
  "base64",
  "derive_more",
+ "dot",
  "env_logger",
  "futures",
  "hex",
@@ -376,6 +377,12 @@ checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "dot"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a74b6c4d4a1cff5f454164363c16b72fa12463ca6b31f4b5f2035a65fa3d5906"
 
 [[package]]
 name = "either"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,7 +115,6 @@ dependencies = [
  "anyhow",
  "banyan",
  "base64",
- "clap",
  "derive_more",
  "env_logger",
  "futures",
@@ -135,6 +134,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smol_str",
+ "structopt",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -1754,6 +1754,30 @@ name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "structopt"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5277acd7ee46e63e5168a80734c9f6ee81b1367a7d8772a2d765df2a3705d28c"
+dependencies = [
+ "clap",
+ "lazy_static",
+ "structopt-derive",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ba9cdfda491b814720b6b06e0cac513d922fc407582032e8706e9f137976f90"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "subtle"

--- a/banyan-cli/Cargo.toml
+++ b/banyan-cli/Cargo.toml
@@ -11,7 +11,6 @@ categories = ["data-structures"]
 anyhow = "1.0.38"
 banyan = { path = "../banyan" }
 base64 = "0.13.0"
-clap = "2.33.3"
 derive_more = "0.99.11"
 env_logger = "0.8.2"
 futures = "0.3.12"
@@ -29,6 +28,7 @@ salsa20 = "0.7.2"
 serde = { version = "1.0.123", features = ["derive", "rc"] }
 serde_json = "1.0.62"
 smol_str = { version = "0.1.17", features = ["serde"] }
+structopt = "0.3.21"
 tokio = { version = "1.2.0", features = ["full"] }
 tracing = "0.1.23"
 tracing-subscriber = "0.2.15"

--- a/banyan-cli/Cargo.toml
+++ b/banyan-cli/Cargo.toml
@@ -12,6 +12,7 @@ anyhow = "1.0.38"
 banyan = { path = "../banyan" }
 base64 = "0.13.0"
 derive_more = "0.99.11"
+dot = "0.1.4"
 env_logger = "0.8.2"
 futures = "0.3.12"
 hex = "0.4.2"

--- a/banyan-cli/Cargo.toml
+++ b/banyan-cli/Cargo.toml
@@ -15,7 +15,7 @@ derive_more = "0.99.11"
 env_logger = "0.8.2"
 futures = "0.3.12"
 hex = "0.4.2"
-ipfs-sqlite-block-store = "0.1.12"
+ipfs-sqlite-block-store = "0.2.2"
 libipld = { version = "0.11.0", features = ["unleashed"] }
 lru = "0.6.4"
 maplit = "1.0.2"

--- a/banyan-cli/src/dump.rs
+++ b/banyan-cli/src/dump.rs
@@ -1,0 +1,134 @@
+use core::fmt::Debug;
+use std::collections::BTreeMap;
+
+use banyan::{
+    forest::{Transaction, TreeTypes},
+    store::ReadOnlyStore,
+    tree::Tree,
+};
+use libipld::cbor::DagCbor;
+
+type Node<'a> = &'a NodeDescriptor;
+type Edge<'a> = (usize, usize);
+struct ForestWithTree {
+    nodes: BTreeMap<usize, NodeDescriptor>,
+    edges: Vec<(usize, usize)>,
+}
+
+#[allow(dead_code)]
+enum NodeDescriptor {
+    Branch {
+        level: usize,
+        id: usize,
+        sealed: bool,
+    },
+    Leaf {
+        id: usize,
+        items: u32,
+        bytes: u64,
+        sealed: bool,
+    },
+}
+
+impl<'a> dot::Labeller<'a, Node<'a>, Edge<'a>> for ForestWithTree {
+    fn graph_id(&'a self) -> dot::Id<'a> {
+        dot::Id::new("thetree").unwrap()
+    }
+
+    fn node_id(&'a self, n: &&'a NodeDescriptor) -> dot::Id<'a> {
+        let id = match n {
+            NodeDescriptor::Branch { id, .. } => id,
+            NodeDescriptor::Leaf { id, .. } => id,
+        };
+        dot::Id::new(format!("N{}", id)).unwrap()
+    }
+    fn node_label(&'a self, n: &&'a NodeDescriptor) -> dot::LabelText<'a> {
+        let id = match n {
+            NodeDescriptor::Branch { id, .. } => id.to_string(),
+            NodeDescriptor::Leaf { items, .. } => items.to_string(),
+        };
+        dot::LabelText::label(id)
+    }
+
+    fn node_shape(&'a self, n: &Node<'a>) -> Option<dot::LabelText<'a>> {
+        let id = match n {
+            NodeDescriptor::Branch { .. } => "box",
+            NodeDescriptor::Leaf { .. } => "circle",
+        };
+        Some(dot::LabelText::label(id))
+    }
+
+    fn node_color(&'a self, n: &Node<'a>) -> Option<dot::LabelText<'a>> {
+        let sealed = match n {
+            NodeDescriptor::Branch { sealed, .. } => sealed,
+            NodeDescriptor::Leaf { sealed, .. } => sealed,
+        };
+        if *sealed {
+            Some(dot::LabelText::label("grey"))
+        } else {
+            None
+        }
+    }
+
+    fn node_style(&'a self, n: &Node<'a>) -> dot::Style {
+        let sealed = match n {
+            NodeDescriptor::Branch { sealed, .. } => sealed,
+            NodeDescriptor::Leaf { sealed, .. } => sealed,
+        };
+        if *sealed {
+            dot::Style::Filled
+        } else {
+            dot::Style::None
+        }
+    }
+}
+
+impl<'a> dot::GraphWalk<'a, Node<'a>, Edge<'a>> for ForestWithTree {
+    fn nodes(&'a self) -> dot::Nodes<'a, Node<'a>> {
+        self.nodes.values().collect()
+    }
+
+    fn edges(&'a self) -> dot::Edges<'a, Edge<'a>> {
+        self.edges.iter().cloned().collect()
+    }
+
+    fn source(&'a self, edge: &Edge<'a>) -> Node<'a> {
+        &self.nodes[&edge.0]
+    }
+
+    fn target(&'a self, edge: &Edge<'a>) -> Node<'a> {
+        &self.nodes[&edge.1]
+    }
+}
+
+pub fn graph<TT, V, R, W>(
+    forest: &Transaction<TT, V, R, W>,
+    tree: &Tree<TT>,
+    mut out: impl std::io::Write,
+) -> anyhow::Result<()>
+where
+    TT: TreeTypes,
+    V: Clone + Send + Sync + Debug + DagCbor + 'static,
+    R: ReadOnlyStore<TT::Link> + Clone + Send + Sync + 'static,
+{
+    let (edges, nodes) = forest.dump_graph(&tree, |(id, node)| match node {
+        banyan::index::NodeInfo::Branch(idx, _) | banyan::index::NodeInfo::PurgedBranch(idx) => {
+            NodeDescriptor::Branch {
+                level: idx.level as usize,
+                id,
+                sealed: idx.sealed,
+            }
+        }
+        banyan::index::NodeInfo::Leaf(idx, _) | banyan::index::NodeInfo::PurgedLeaf(idx) => {
+            NodeDescriptor::Leaf {
+                id,
+                items: idx.keys().fold(0, |acc, _| acc + 1),
+                bytes: idx.value_bytes,
+                sealed: idx.sealed,
+            }
+        }
+    })?;
+    let forest_with_tree = ForestWithTree { nodes, edges };
+    dot::render(&forest_with_tree, &mut out)?;
+    Ok(())
+}

--- a/banyan-cli/src/main.rs
+++ b/banyan-cli/src/main.rs
@@ -1,5 +1,6 @@
 use futures::future::poll_fn;
 use futures::prelude::*;
+use ipfs_sqlite_block_store::BlockStore;
 use sqlite::SqliteStore;
 use std::{collections::BTreeMap, str::FromStr, sync::Arc, time::Duration};
 use structopt::StructOpt;
@@ -60,7 +61,10 @@ impl FromStr for Storage {
         let s = match s {
             "memory" => Self::Memory(MemStore::new(usize::max_value(), Sha256Digest::new)),
             "ipfs" => Self::Ipfs(IpfsStore::new()?),
-            x => Self::Sqlite(SqliteStore::new(x)?),
+            x => Self::Sqlite(SqliteStore::new(BlockStore::open(
+                x,
+                ipfs_sqlite_block_store::Config::default(),
+            )?)?),
         };
         Ok(s)
     }

--- a/banyan-cli/src/main.rs
+++ b/banyan-cli/src/main.rs
@@ -80,8 +80,6 @@ enum Command {
         /// Base on which to build
         base: Sha256Digest,
     },
-    /// Do some stuff
-    Demo {},
     /// Dump a tree
     Dump {
         #[structopt(long)]
@@ -401,7 +399,6 @@ async fn main() -> Result<()> {
                 (tfilter_rare.as_micros() as f64) / 1000000.0
             );
         }
-        Command::Demo {} => {}
         Command::Filter { tag, root } => {
             let tags = tag
                 .into_iter()

--- a/banyan-cli/src/main.rs
+++ b/banyan-cli/src/main.rs
@@ -1,9 +1,8 @@
-use anyhow::anyhow;
-use clap::{App, Arg, SubCommand};
 use futures::future::poll_fn;
 use futures::prelude::*;
 use sqlite::SqliteStore;
 use std::{collections::BTreeMap, str::FromStr, sync::Arc, time::Duration};
+use structopt::StructOpt;
 use tag_index::{Tag, TagSet};
 use tracing::Level;
 
@@ -30,142 +29,113 @@ pub type Result<T> = anyhow::Result<T>;
 
 type Txn = Transaction<TT, String, ArcReadOnlyStore<Sha256Digest>, ArcBlockWriter<Sha256Digest>>;
 
-fn app() -> clap::App<'static, 'static> {
-    let root_arg = || {
-        Arg::with_name("root")
-            .required(true)
-            .takes_value(true)
-            .help("The root hash to use")
+#[derive(StructOpt)]
+#[structopt(about = "CLI to work with large banyan trees on ipfs")]
+struct Opts {
+    #[structopt(long, global = true)]
+    /// An index password to use
+    index_pass: Option<String>,
+    #[structopt(long, global = true)]
+    /// A value password to use
+    value_pass: Option<String>,
+    #[structopt(short, parse(from_occurrences = set_log_level), global = true)]
+    #[allow(dead_code)] // log level will bet set in [`set_log_level`]
+    /// Increase verbosity
+    verbosity: u64,
+    #[structopt(subcommand)]
+    cmd: Command,
+}
+
+fn set_log_level(verbosity: u64) -> u64 {
+    let level = match verbosity {
+        0 => Level::ERROR,
+        1 => Level::INFO,
+        2 => Level::DEBUG,
+        _ => Level::TRACE,
     };
-    let topic_arg = || {
-        Arg::with_name("topic")
-            .long("topic")
-            .required(true)
-            .takes_value(true)
-            .help("The topic to send/recv data over")
-    };
-    let index_pass_arg = || {
-        Arg::with_name("index_pass")
-            .long("index_pass")
-            .required(false)
-            .takes_value(true)
-            .help("An index password to use")
-    };
-    let value_pass_arg = || {
-        Arg::with_name("value_pass")
-            .long("value_pass")
-            .required(false)
-            .takes_value(true)
-            .help("A value password to use")
-    };
-    let verbose_arg = || {
-        Arg::with_name("verbose")
-            .short("v")
-            .multiple(true)
-            .help("Sets the level of verbosity")
-    };
-    App::new("banyan-cli")
-        .version("0.1")
-        .author("Rüdiger Klaehn")
-        .about("CLI to work with large banyan trees on ipfs")
-        .arg(index_pass_arg())
-        .arg(value_pass_arg())
-        .arg(verbose_arg())
-        .subcommand(
-            SubCommand::with_name("dump")
-                .about("Dump a tree")
-                .arg(root_arg()),
-        )
-        .subcommand(
-            SubCommand::with_name("stream")
-                .about("Stream a tree")
-                .arg(root_arg()),
-        )
-        .subcommand(
-            SubCommand::with_name("build")
-                .about("Build a tree")
-                .arg(
-                    Arg::with_name("count")
-                        .long("count")
-                        .required(true)
-                        .takes_value(true)
-                        .help("The number of values per batch"),
-                )
-                .arg(
-                    Arg::with_name("batches")
-                        .long("batches")
-                        .takes_value(true)
-                        .default_value("1")
-                        .help("The number of batches"),
-                )
-                .arg(
-                    Arg::with_name("unbalanced")
-                        .long("unbalanced")
-                        .takes_value(false)
-                        .help("Do not balance while building"),
-                )
-                .arg(
-                    Arg::with_name("base")
-                        .long("base")
-                        .takes_value(true)
-                        .help("Base on which to build"),
-                ),
-        )
-        .subcommand(
-            SubCommand::with_name("filter")
-                .about("Stream a tree, filtered")
-                .arg(root_arg())
-                .arg(
-                    Arg::with_name("tag")
-                        .long("tag")
-                        .required(true)
-                        .multiple(true)
-                        .takes_value(true)
-                        .help("Tags to filter"),
-                ),
-        )
-        .subcommand(
-            SubCommand::with_name("pack")
-                .about("Pack a tree")
-                .arg(root_arg()),
-        )
-        .subcommand(
-            SubCommand::with_name("repair")
-                .about("Repair a tree")
-                .arg(root_arg()),
-        )
-        .subcommand(
-            SubCommand::with_name("send_stream")
-                .about("Send a stream")
-                .arg(topic_arg()),
-        )
-        .subcommand(
-            SubCommand::with_name("recv_stream")
-                .about("Receive a stream")
-                .arg(topic_arg()),
-        )
-        .subcommand(
-            SubCommand::with_name("forget")
-                .about("Forget data from a tree")
-                .arg(root_arg())
-                .arg(
-                    Arg::with_name("before")
-                        .long("before")
-                        .required(true)
-                        .takes_value(true)
-                        .help("The offset before which to forget data"),
-                ),
-        )
-        .subcommand(SubCommand::with_name("demo").about("Do some stuff"))
-        .subcommand(
-            SubCommand::with_name("bench").about("Benchmark").arg(
-                Arg::with_name("count")
-                    .long("count")
-                    .required(true)
-                    .takes_value(true)
-                    .help("The number of values per batch"),
-            ),
-        )
+    tracing_subscriber::fmt().with_max_level(level).init();
+    verbosity
+}
+
+#[derive(StructOpt)]
+enum Command {
+    /// Benchmark
+    Bench {
+        #[structopt(long)]
+        /// The number of values per batch
+        count: u64,
+    },
+    /// Build a tree
+    Build {
+        #[structopt(long)]
+        /// The number of values per batch
+        count: u64,
+        #[structopt(long, default_value = "1")]
+        /// The number of batches
+        batches: u64,
+        #[structopt(long)]
+        /// Do not balance while building
+        unbalanced: bool,
+        #[structopt(long)]
+        /// Base on which to build
+        base: Sha256Digest,
+    },
+    /// Do some stuff
+    Demo {},
+    /// Dump a tree
+    Dump {
+        #[structopt(long)]
+        /// The root hash to use
+        root: Sha256Digest,
+    },
+    /// Stream a tree, filtered
+    Filter {
+        #[structopt(long)]
+        /// The root hash to use
+        root: Sha256Digest,
+        #[structopt(long)]
+        /// Tags to filter
+        tag: Vec<String>,
+    },
+    /// Forget data from a tree
+    Forget {
+        #[structopt(long)]
+        /// The root hash to use
+        root: Sha256Digest,
+        #[structopt(long)]
+        /// The offset before which to forget data
+        before: u64,
+    },
+    /// Pack a tree
+    Pack {
+        #[structopt(long)]
+        /// The root hash to use
+        root: Sha256Digest,
+    },
+    /// Receive a stream
+    RecvStream {
+        #[structopt(long)]
+        /// Topic to receive data over
+        topic: String,
+    },
+    /// Repair a tree
+    Repair {
+        #[structopt(long)]
+        /// The root hash to use
+        root: Sha256Digest,
+    },
+    /// Send a stream
+    SendStream {
+        #[structopt(long)]
+        /// Topic to send data over
+        topic: String,
+    },
+    /// Stream a tree
+    Stream {
+        #[structopt(long)]
+        /// The root hash to use
+        root: Sha256Digest,
+    },
 }
 
 struct Tagger(BTreeMap<&'static str, Tag>);
@@ -184,7 +154,7 @@ impl Tagger {
     }
 }
 
-fn create_salsa_key(text: &str) -> salsa20::Key {
+fn create_salsa_key(text: String) -> salsa20::Key {
     let mut key = [0u8; 32];
     for (i, v) in text.as_bytes().iter().take(32).enumerate() {
         key[i] = *v;
@@ -302,6 +272,7 @@ async fn bench_build(
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    let opts = Opts::from_args();
     let mut tagger = Tagger::new();
     // function to add some arbitrary tags to test out tag querying and compression
     let mut tags_from_offset = |i: u64| -> TagSet {
@@ -319,23 +290,8 @@ async fn main() -> Result<()> {
     };
 
     let store = Arc::new(IpfsStore::new()?);
-    let matches = app().get_matches();
-    let index_key: salsa20::Key = matches
-        .value_of("index_pass")
-        .map(create_salsa_key)
-        .unwrap_or_default();
-    let value_key: salsa20::Key = matches
-        .value_of("value_pass")
-        .map(create_salsa_key)
-        .unwrap_or_default();
-    let verbosity = matches.occurrences_of("verbose");
-    let level = match verbosity {
-        0 => Level::ERROR,
-        1 => Level::INFO,
-        2 => Level::DEBUG,
-        _ => Level::TRACE,
-    };
-    tracing_subscriber::fmt().with_max_level(level).init();
+    let index_key: salsa20::Key = opts.index_pass.map(create_salsa_key).unwrap_or_default();
+    let value_key: salsa20::Key = opts.value_pass.map(create_salsa_key).unwrap_or_default();
     let config = Config::debug_fast();
     let crypto_config = CryptoConfig {
         index_key,
@@ -349,220 +305,174 @@ async fn main() -> Result<()> {
         )
     };
     let forest = txn();
-    if let Some(matches) = matches.subcommand_matches("dump") {
-        let root = Sha256Digest::from_str(
-            matches
-                .value_of("root")
-                .ok_or_else(|| anyhow!("root must be provided"))?,
-        )?;
-        let tree = forest.load_tree(root)?;
-        forest.dump(&tree)?;
-        return Ok(());
-    } else if let Some(matches) = matches.subcommand_matches("stream") {
-        let root = Sha256Digest::from_str(
-            matches
-                .value_of("root")
-                .ok_or_else(|| anyhow!("root must be provided"))?,
-        )?;
-        let tree = forest.load_tree(root)?;
-        let mut stream = forest.stream_filtered(&tree, AllQuery).enumerate();
-        while let Some((i, Ok(v))) = stream.next().await {
-            if i % 1000 == 0 {
-                println!("{:?}", v);
+    match opts.cmd {
+        Command::Dump { root } => {
+            let tree = forest.load_tree(root)?;
+            forest.dump(&tree)?;
+        }
+        Command::Stream { root } => {
+            let tree = forest.load_tree(root)?;
+            let mut stream = forest.stream_filtered(&tree, AllQuery).enumerate();
+            while let Some((i, Ok(v))) = stream.next().await {
+                if i % 1000 == 0 {
+                    println!("{:?}", v);
+                }
             }
         }
-        return Ok(());
-    } else if let Some(matches) = matches.subcommand_matches("build") {
-        let count: u64 = matches
-            .value_of("count")
-            .ok_or_else(|| anyhow!("required arg count not provided"))?
-            .parse()?;
-        let batches: u64 = matches
-            .value_of("batches")
-            .ok_or_else(|| anyhow!("required arg count not provided"))?
-            .parse()?;
-        let unbalanced = matches.is_present("unbalanced");
-        let base = matches
-            .value_of("base")
-            .map(Sha256Digest::from_str)
-            .transpose()?;
-        println!(
-            "building a tree with {} batches of {} values, unbalanced: {}",
-            batches, count, unbalanced
-        );
-        let tree = build_tree(&forest, base, batches, count, unbalanced, 1000).await?;
-        forest.dump(&tree)?;
-        let roots = forest.roots(&tree)?;
-        let levels = roots.iter().map(|x| x.level()).collect::<Vec<_>>();
-        let _tree2 = forest.tree_from_roots(roots)?;
-        println!("{:?}", tree);
-        println!("{}", tree);
-        println!("{:?}", levels);
-        forest.dump(&tree)?;
-    } else if let Some(matches) = matches.subcommand_matches("pack") {
-        let root = Sha256Digest::from_str(
-            matches
-                .value_of("root")
-                .ok_or_else(|| anyhow!("root must be provided"))?,
-        )?;
-        let mut tree = forest.load_tree(root)?;
-        forest.dump(&tree)?;
-        tree = forest.pack(&tree)?;
-        forest.assert_invariants(&tree)?;
-        assert!(forest.is_packed(&tree)?);
-        forest.dump(&tree)?;
-        println!("{:?}", tree);
-    } else if let Some(matches) = matches.subcommand_matches("filter") {
-        let root = Sha256Digest::from_str(
-            matches
-                .value_of("root")
-                .ok_or_else(|| anyhow!("root must be provided"))?,
-        )?;
-        let tags = matches
-            .values_of("tag")
-            .ok_or_else(|| anyhow!("at least one tag must be provided"))?
-            .map(|tag| Key::filter_tags(TagSet::single(Tag::from(tag))))
-            .collect::<Vec<_>>();
-        let query = DnfQuery(tags).boxed();
-        let tree = forest.load_tree(root)?;
-        forest.dump(&tree)?;
-        let mut stream = forest.stream_filtered(&tree, query).enumerate();
-        while let Some((i, Ok(v))) = stream.next().await {
-            if i % 1000 == 0 {
-                println!("{:?}", v);
+        Command::Build {
+            base,
+            batches,
+            count,
+            unbalanced,
+        } => {
+            println!(
+                "building a tree with {} batches of {} values, unbalanced: {}",
+                batches, count, unbalanced
+            );
+            let tree = build_tree(&forest, Some(base), batches, count, unbalanced, 1000).await?;
+            forest.dump(&tree)?;
+            let roots = forest.roots(&tree)?;
+            let levels = roots.iter().map(|x| x.level()).collect::<Vec<_>>();
+            let _tree2 = forest.tree_from_roots(roots)?;
+            println!("{:?}", tree);
+            println!("{}", tree);
+            println!("{:?}", levels);
+            forest.dump(&tree)?;
+        }
+        Command::Bench { count } => {
+            let store = Arc::new(SqliteStore::memory()?);
+            let config = Config::debug_fast();
+            let crypto_config = CryptoConfig {
+                index_key,
+                value_key,
+            };
+            let branch_cache = BranchCache::new(1000);
+            let forest = Txn::new(
+                Forest::new(store.clone(), branch_cache, crypto_config, config),
+                store,
+            );
+            let _t0 = std::time::Instant::now();
+            let base = None;
+            let batches = 1;
+            let unbalanced = false;
+            let (tree, tcreate) = bench_build(&forest, base, batches, count, unbalanced).await?;
+            let t0 = std::time::Instant::now();
+            let _values: Vec<_> = forest.collect(&tree)?;
+            let t1 = std::time::Instant::now();
+            let tcollect = t1 - t0;
+            let t0 = std::time::Instant::now();
+            let tags = vec![Key::range(
+                0,
+                u64::max_value(),
+                TagSet::single(Tag::from("fizz")),
+            )];
+            let query = DnfQuery(tags).boxed();
+            let values: Vec<_> = forest
+                .stream_filtered(&tree, query)
+                .map_ok(|(_, k, v)| (k, v))
+                .collect::<Vec<_>>()
+                .await;
+            println!("{}", values.len());
+            let t1 = std::time::Instant::now();
+            let tfilter_common = t1 - t0;
+            let t0 = std::time::Instant::now();
+            let tags = vec![Key::range(
+                0,
+                count / 10,
+                TagSet::single(Tag::from("fizzbuzz")),
+            )];
+            let query = DnfQuery(tags).boxed();
+            let values: Vec<_> = forest
+                .stream_filtered(&tree, query)
+                .map_ok(|(_, k, v)| (k, v))
+                .collect::<Vec<_>>()
+                .await;
+            println!("{}", values.len());
+            let t1 = std::time::Instant::now();
+            let tfilter_rare = t1 - t0;
+            println!("create {}", (tcreate.as_micros() as f64) / 1000000.0);
+            println!("collect {}", (tcollect.as_micros() as f64) / 1000000.0);
+            println!(
+                "filter_common {}",
+                (tfilter_common.as_micros() as f64) / 1000000.0
+            );
+            println!(
+                "filter_rare {}",
+                (tfilter_rare.as_micros() as f64) / 1000000.0
+            );
+        }
+        Command::Demo {} => {}
+        Command::Filter { tag, root } => {
+            let tags = tag
+                .into_iter()
+                .map(|tag| Key::filter_tags(TagSet::single(Tag::from(tag))))
+                .collect::<Vec<_>>();
+            let query = DnfQuery(tags).boxed();
+            let tree = forest.load_tree(root)?;
+            forest.dump(&tree)?;
+            let mut stream = forest.stream_filtered(&tree, query).enumerate();
+            while let Some((i, Ok(v))) = stream.next().await {
+                if i % 1000 == 0 {
+                    println!("{:?}", v);
+                }
             }
         }
-    } else if let Some(matches) = matches.subcommand_matches("repair") {
-        let root = Sha256Digest::from_str(
-            matches
-                .value_of("root")
-                .ok_or_else(|| anyhow!("root must be provided"))?,
-        )?;
-        let tree = forest.load_tree(root)?;
-        let (tree, _) = forest.repair(&tree)?;
-        forest.dump(&tree)?;
-        println!("{:?}", tree);
-    } else if let Some(matches) = matches.subcommand_matches("forget") {
-        let root = Sha256Digest::from_str(
-            matches
-                .value_of("root")
-                .ok_or_else(|| anyhow!("root must be provided"))?,
-        )?;
-        let offset: u64 = matches
-            .value_of("before")
-            .ok_or_else(|| anyhow!("required arg before not provided"))?
-            .parse()?;
-        let mut tree = forest.load_tree(root)?;
-        tree = forest.retain(&tree, &OffsetRangeQuery::from(offset..))?;
-        forest.dump(&tree)?;
-        println!("{:?}", tree);
-    } else if let Some(matches) = matches.subcommand_matches("send_stream") {
-        let topic = matches
-            .value_of("topic")
-            .ok_or_else(|| anyhow!("topic must be provided"))?;
-        let mut ticks = tokio::time::interval(Duration::from_secs(1));
-        let mut tree = Tree::<TT>::empty();
-        let mut offset = 0;
-        loop {
-            poll_fn(|cx| ticks.poll_tick(cx)).await;
-            let key = Key::single(offset, offset, tags_from_offset(offset));
-            tree = forest.extend_unpacked(&tree, Some((key, "xxx".into())))?;
-            if tree.level() > 100 {
-                println!("packing the tree");
-                tree = forest.pack(&tree)?;
-            }
-            offset += 1;
-            if let Some(cid) = tree.link() {
-                println!("publishing {} to {}", cid, topic);
-                pubsub_pub(topic, cid.to_string().as_bytes()).await?;
+        Command::Forget { root, before } => {
+            let mut tree = forest.load_tree(root)?;
+            tree = forest.retain(&tree, &OffsetRangeQuery::from(before..))?;
+            forest.dump(&tree)?;
+            println!("{:?}", tree);
+        }
+        Command::Pack { root } => {
+            let mut tree = forest.load_tree(root)?;
+            forest.dump(&tree)?;
+            tree = forest.pack(&tree)?;
+            forest.assert_invariants(&tree)?;
+            assert!(forest.is_packed(&tree)?);
+            forest.dump(&tree)?;
+            println!("{:?}", tree);
+        }
+        Command::RecvStream { topic } => {
+            let stream = pubsub_sub(&*topic)?
+                .map_err(anyhow::Error::new)
+                .and_then(|data| future::ready(String::from_utf8(data).map_err(anyhow::Error::new)))
+                .and_then(|data| future::ready(Sha256Digest::from_str(&data)));
+            let forest2 = forest.clone();
+            let trees = stream.filter_map(move |x| {
+                let forest = forest2.clone();
+                future::ready(x.and_then(move |link| forest.load_tree(link)).ok())
+            });
+            let mut stream = forest.read().stream_trees(AllQuery, trees).boxed_local();
+            while let Some(ev) = stream.next().await {
+                println!("{:?}", ev);
             }
         }
-    } else if let Some(matches) = matches.subcommand_matches("recv_stream") {
-        let topic = matches
-            .value_of("topic")
-            .ok_or_else(|| anyhow!("topic must be provided"))?;
-        let stream = pubsub_sub(topic)?
-            .map_err(anyhow::Error::new)
-            .and_then(|data| future::ready(String::from_utf8(data).map_err(anyhow::Error::new)))
-            .and_then(|data| future::ready(Sha256Digest::from_str(&data)));
-        let forest2 = forest.clone();
-        let trees = stream.filter_map(move |x| {
-            let forest = forest2.clone();
-            future::ready(x.and_then(move |link| forest.load_tree(link)).ok())
-        });
-        let mut stream = forest.read().stream_trees(AllQuery, trees).boxed_local();
-        while let Some(ev) = stream.next().await {
-            println!("{:?}", ev);
+        Command::Repair { root } => {
+            let tree = forest.load_tree(root)?;
+            let (tree, _) = forest.repair(&tree)?;
+            forest.dump(&tree)?;
+            println!("{:?}", tree);
         }
-    } else if let Some(matches) = matches.subcommand_matches("bench") {
-        // let store = Arc::new(MemStore::new(usize::max_value(), Sha256Digest::new));
-        let store = Arc::new(SqliteStore::memory()?);
-        let config = Config::debug_fast();
-        let crypto_config = CryptoConfig {
-            index_key,
-            value_key,
-        };
-        let branch_cache = BranchCache::new(1000);
-        let forest = Txn::new(
-            Forest::new(store.clone(), branch_cache, crypto_config, config),
-            store,
-        );
-        let _t0 = std::time::Instant::now();
-        let base = None;
-        let batches = 1;
-        let count: u64 = matches
-            .value_of("count")
-            .ok_or_else(|| anyhow!("required arg count not provided"))?
-            .parse()?;
-        let unbalanced = false;
-        let (tree, tcreate) = bench_build(&forest, base, batches, count, unbalanced).await?;
-        let t0 = std::time::Instant::now();
-        let _values: Vec<_> = forest.collect(&tree)?;
-        let t1 = std::time::Instant::now();
-        let tcollect = t1 - t0;
-        let t0 = std::time::Instant::now();
-        let tags = vec![Key::range(
-            0,
-            u64::max_value(),
-            TagSet::single(Tag::from("fizz")),
-        )];
-        let query = DnfQuery(tags).boxed();
-        let values: Vec<_> = forest
-            .stream_filtered(&tree, query)
-            .map_ok(|(_, k, v)| (k, v))
-            .collect::<Vec<_>>()
-            .await;
-        println!("{}", values.len());
-        let t1 = std::time::Instant::now();
-        let tfilter_common = t1 - t0;
-        let t0 = std::time::Instant::now();
-        let tags = vec![Key::range(
-            0,
-            count / 10,
-            TagSet::single(Tag::from("fizzbuzz")),
-        )];
-        let query = DnfQuery(tags).boxed();
-        let values: Vec<_> = forest
-            .stream_filtered(&tree, query)
-            .map_ok(|(_, k, v)| (k, v))
-            .collect::<Vec<_>>()
-            .await;
-        println!("{}", values.len());
-        let t1 = std::time::Instant::now();
-        let tfilter_rare = t1 - t0;
-        println!("create {}", (tcreate.as_micros() as f64) / 1000000.0);
-        println!("collect {}", (tcollect.as_micros() as f64) / 1000000.0);
-        println!(
-            "filter_common {}",
-            (tfilter_common.as_micros() as f64) / 1000000.0
-        );
-        println!(
-            "filter_rare {}",
-            (tfilter_rare.as_micros() as f64) / 1000000.0
-        );
-    } else {
-        app().print_long_help()?;
-        println!();
+        Command::SendStream { topic } => {
+            let mut ticks = tokio::time::interval(Duration::from_secs(1));
+            let mut tree = Tree::<TT>::empty();
+            let mut offset = 0;
+            loop {
+                poll_fn(|cx| ticks.poll_tick(cx)).await;
+                let key = Key::single(offset, offset, tags_from_offset(offset));
+                tree = forest.extend_unpacked(&tree, Some((key, "xxx".into())))?;
+                if tree.level() > 100 {
+                    println!("packing the tree");
+                    tree = forest.pack(&tree)?;
+                }
+                offset += 1;
+                if let Some(cid) = tree.link() {
+                    println!("publishing {} to {}", cid, topic);
+                    pubsub_pub(&*topic, cid.to_string().as_bytes()).await?;
+                }
+            }
+        }
     }
+
     Ok(())
 }

--- a/banyan-cli/src/main.rs
+++ b/banyan-cli/src/main.rs
@@ -7,6 +7,7 @@ use structopt::StructOpt;
 use tag_index::{Tag, TagSet};
 use tracing::Level;
 
+mod dump;
 mod ipfs;
 mod sqlite;
 mod tag_index;
@@ -321,99 +322,6 @@ async fn bench_build(
     Ok((tree, t1 - t0))
 }
 
-type Node<'a> = &'a NodeDescriptor;
-type Edge<'a> = (usize, usize);
-struct ForestWithTree {
-    nodes: BTreeMap<usize, NodeDescriptor>,
-    edges: Vec<(usize, usize)>,
-}
-
-#[allow(dead_code)]
-enum NodeDescriptor {
-    Branch {
-        level: usize,
-        id: usize,
-        sealed: bool,
-    },
-    Leaf {
-        id: usize,
-        items: u32,
-        bytes: u64,
-        sealed: bool,
-    },
-}
-
-impl<'a> dot::Labeller<'a, Node<'a>, Edge<'a>> for ForestWithTree {
-    fn graph_id(&'a self) -> dot::Id<'a> {
-        dot::Id::new("thetree").unwrap()
-    }
-
-    fn node_id(&'a self, n: &&'a NodeDescriptor) -> dot::Id<'a> {
-        let id = match n {
-            NodeDescriptor::Branch { id, .. } => id,
-            NodeDescriptor::Leaf { id, .. } => id,
-        };
-        dot::Id::new(format!("N{}", id)).unwrap()
-    }
-    fn node_label(&'a self, n: &&'a NodeDescriptor) -> dot::LabelText<'a> {
-        let id = match n {
-            NodeDescriptor::Branch { id, .. } => id.to_string(),
-            NodeDescriptor::Leaf { items, .. } => items.to_string(),
-        };
-        dot::LabelText::label(id)
-    }
-
-    fn node_shape(&'a self, n: &Node<'a>) -> Option<dot::LabelText<'a>> {
-        let id = match n {
-            NodeDescriptor::Branch { .. } => "box",
-            NodeDescriptor::Leaf { .. } => "circle",
-        };
-        Some(dot::LabelText::label(id))
-    }
-
-    fn node_color(&'a self, n: &Node<'a>) -> Option<dot::LabelText<'a>> {
-        let sealed = match n {
-            NodeDescriptor::Branch { sealed, .. } => sealed,
-            NodeDescriptor::Leaf { sealed, .. } => sealed,
-        };
-        if *sealed {
-            Some(dot::LabelText::label("grey"))
-        } else {
-            None
-        }
-    }
-
-    fn node_style(&'a self, n: &Node<'a>) -> dot::Style {
-        let sealed = match n {
-            NodeDescriptor::Branch { sealed, .. } => sealed,
-            NodeDescriptor::Leaf { sealed, .. } => sealed,
-        };
-        if *sealed {
-            dot::Style::Filled
-        } else {
-            dot::Style::None
-        }
-    }
-}
-
-impl<'a> dot::GraphWalk<'a, Node<'a>, Edge<'a>> for ForestWithTree {
-    fn nodes(&'a self) -> dot::Nodes<'a, Node<'a>> {
-        self.nodes.values().collect()
-    }
-
-    fn edges(&'a self) -> dot::Edges<'a, Edge<'a>> {
-        self.edges.iter().cloned().collect()
-    }
-
-    fn source(&'a self, edge: &Edge<'a>) -> Node<'a> {
-        &self.nodes[&edge.0]
-    }
-
-    fn target(&'a self, edge: &Edge<'a>) -> Node<'a> {
-        &self.nodes[&edge.1]
-    }
-}
-
 #[tokio::main]
 async fn main() -> Result<()> {
     let opts = Opts::from_args();
@@ -452,24 +360,8 @@ async fn main() -> Result<()> {
     match opts.cmd {
         Command::Graph { root } => {
             let tree = forest.load_tree(root)?;
-            let (edges, nodes) = forest.dump_graph(&tree, |(id, node)| match node {
-                banyan::index::NodeInfo::Branch(idx, _)
-                | banyan::index::NodeInfo::PurgedBranch(idx) => NodeDescriptor::Branch {
-                    level: idx.level as usize,
-                    id,
-                    sealed: idx.sealed,
-                },
-                banyan::index::NodeInfo::Leaf(idx, _)
-                | banyan::index::NodeInfo::PurgedLeaf(idx) => NodeDescriptor::Leaf {
-                    id,
-                    items: idx.keys().fold(0, |acc, _| acc + 1),
-                    bytes: idx.value_bytes,
-                    sealed: idx.sealed,
-                },
-            })?;
-            let forest_with_tree = ForestWithTree { nodes, edges };
             let mut stdout = std::io::stdout();
-            dot::render(&forest_with_tree, &mut stdout)?;
+            dump::graph(&forest, &tree, &mut stdout)?;
         }
         Command::Dump { root } => {
             let tree = forest.load_tree(root)?;

--- a/banyan-cli/src/main.rs
+++ b/banyan-cli/src/main.rs
@@ -120,6 +120,15 @@ enum Command {
         /// Base on which to build
         base: Option<Sha256Digest>,
     },
+    /// Traverse a tree and dump its output as dot. Can be piped directly:
+    /// `banyan-cli graph --root <..> | dot -Tpng output.png`.
+    /// Branches are depicted as rectangles, leafs as circles. A sealed node is
+    /// greyed out.
+    Graph {
+        #[structopt(long)]
+        /// The root hash to use
+        root: Sha256Digest,
+    },
     /// Dump a tree
     Dump {
         #[structopt(long)]
@@ -308,6 +317,99 @@ async fn bench_build(
     Ok((tree, t1 - t0))
 }
 
+type Node<'a> = &'a NodeDescriptor;
+type Edge<'a> = (usize, usize);
+struct ForestWithTree {
+    nodes: BTreeMap<usize, NodeDescriptor>,
+    edges: Vec<(usize, usize)>,
+}
+
+#[allow(dead_code)]
+enum NodeDescriptor {
+    Branch {
+        level: usize,
+        id: usize,
+        sealed: bool,
+    },
+    Leaf {
+        id: usize,
+        items: u32,
+        bytes: u64,
+        sealed: bool,
+    },
+}
+
+impl<'a> dot::Labeller<'a, Node<'a>, Edge<'a>> for ForestWithTree {
+    fn graph_id(&'a self) -> dot::Id<'a> {
+        dot::Id::new("thetree").unwrap()
+    }
+
+    fn node_id(&'a self, n: &&'a NodeDescriptor) -> dot::Id<'a> {
+        let id = match n {
+            NodeDescriptor::Branch { id, .. } => id,
+            NodeDescriptor::Leaf { id, .. } => id,
+        };
+        dot::Id::new(format!("N{}", id)).unwrap()
+    }
+    fn node_label(&'a self, n: &&'a NodeDescriptor) -> dot::LabelText<'a> {
+        let id = match n {
+            NodeDescriptor::Branch { id, .. } => id.to_string(),
+            NodeDescriptor::Leaf { items, .. } => items.to_string(),
+        };
+        dot::LabelText::label(id)
+    }
+
+    fn node_shape(&'a self, n: &Node<'a>) -> Option<dot::LabelText<'a>> {
+        let id = match n {
+            NodeDescriptor::Branch { .. } => "box",
+            NodeDescriptor::Leaf { .. } => "circle",
+        };
+        Some(dot::LabelText::label(id))
+    }
+
+    fn node_color(&'a self, n: &Node<'a>) -> Option<dot::LabelText<'a>> {
+        let sealed = match n {
+            NodeDescriptor::Branch { sealed, .. } => sealed,
+            NodeDescriptor::Leaf { sealed, .. } => sealed,
+        };
+        if *sealed {
+            Some(dot::LabelText::label("grey"))
+        } else {
+            None
+        }
+    }
+
+    fn node_style(&'a self, n: &Node<'a>) -> dot::Style {
+        let sealed = match n {
+            NodeDescriptor::Branch { sealed, .. } => sealed,
+            NodeDescriptor::Leaf { sealed, .. } => sealed,
+        };
+        if *sealed {
+            dot::Style::Filled
+        } else {
+            dot::Style::None
+        }
+    }
+}
+
+impl<'a> dot::GraphWalk<'a, Node<'a>, Edge<'a>> for ForestWithTree {
+    fn nodes(&'a self) -> dot::Nodes<'a, Node<'a>> {
+        self.nodes.values().collect()
+    }
+
+    fn edges(&'a self) -> dot::Edges<'a, Edge<'a>> {
+        self.edges.iter().cloned().collect()
+    }
+
+    fn source(&'a self, edge: &Edge<'a>) -> Node<'a> {
+        &self.nodes[&edge.0]
+    }
+
+    fn target(&'a self, edge: &Edge<'a>) -> Node<'a> {
+        &self.nodes[&edge.1]
+    }
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     let opts = Opts::from_args();
@@ -344,6 +446,27 @@ async fn main() -> Result<()> {
     };
     let forest = txn();
     match opts.cmd {
+        Command::Graph { root } => {
+            let tree = forest.load_tree(root)?;
+            let (edges, nodes) = forest.dump_graph(&tree, |(id, node)| match node {
+                banyan::index::NodeInfo::Branch(idx, _)
+                | banyan::index::NodeInfo::PurgedBranch(idx) => NodeDescriptor::Branch {
+                    level: idx.level as usize,
+                    id,
+                    sealed: idx.sealed,
+                },
+                banyan::index::NodeInfo::Leaf(idx, _)
+                | banyan::index::NodeInfo::PurgedLeaf(idx) => NodeDescriptor::Leaf {
+                    id,
+                    items: idx.keys().fold(0, |acc, _| acc + 1),
+                    bytes: idx.value_bytes,
+                    sealed: idx.sealed,
+                },
+            })?;
+            let forest_with_tree = ForestWithTree { nodes, edges };
+            let mut stdout = std::io::stdout();
+            dot::render(&forest_with_tree, &mut stdout)?;
+        }
         Command::Dump { root } => {
             let tree = forest.load_tree(root)?;
             forest.dump(&tree)?;

--- a/banyan-cli/src/sqlite.rs
+++ b/banyan-cli/src/sqlite.rs
@@ -13,6 +13,7 @@ use crate::tags::Sha256Digest;
 pub struct SqliteStore(Arc<Mutex<BlockStore>>);
 
 impl SqliteStore {
+    #[allow(dead_code)]
     pub fn memory() -> anyhow::Result<Self> {
         let store = BlockStore::memory(Config::default())?;
         Ok(SqliteStore(Arc::new(Mutex::new(store))))

--- a/banyan-cli/src/sqlite.rs
+++ b/banyan-cli/src/sqlite.rs
@@ -3,7 +3,10 @@ use anyhow::{anyhow, Result};
 use banyan::store::{BlockWriter, ReadOnlyStore};
 use ipfs_sqlite_block_store::{BlockStore, Config, OwnedBlock};
 use libipld::Cid;
-use std::sync::{Arc, Mutex};
+use std::{
+    path::Path,
+    sync::{Arc, Mutex},
+};
 
 use crate::tags::Sha256Digest;
 
@@ -12,6 +15,10 @@ pub struct SqliteStore(Arc<Mutex<BlockStore>>);
 impl SqliteStore {
     pub fn memory() -> anyhow::Result<Self> {
         let store = BlockStore::memory(Config::default())?;
+        Ok(SqliteStore(Arc::new(Mutex::new(store))))
+    }
+    pub fn new(path: impl AsRef<Path>) -> anyhow::Result<Self> {
+        let store = BlockStore::open(path, Config::default())?;
         Ok(SqliteStore(Arc::new(Mutex::new(store))))
     }
 }

--- a/banyan-cli/src/sqlite.rs
+++ b/banyan-cli/src/sqlite.rs
@@ -1,25 +1,16 @@
 //! helper methods to work with ipfs/ipld
 use anyhow::{anyhow, Result};
 use banyan::store::{BlockWriter, ReadOnlyStore};
-use ipfs_sqlite_block_store::{BlockStore, Config, OwnedBlock};
+use ipfs_sqlite_block_store::{BlockStore, OwnedBlock};
 use libipld::Cid;
-use std::{
-    path::Path,
-    sync::{Arc, Mutex},
-};
+use std::sync::{Arc, Mutex};
 
 use crate::tags::Sha256Digest;
 
 pub struct SqliteStore(Arc<Mutex<BlockStore>>);
 
 impl SqliteStore {
-    #[allow(dead_code)]
-    pub fn memory() -> anyhow::Result<Self> {
-        let store = BlockStore::memory(Config::default())?;
-        Ok(SqliteStore(Arc::new(Mutex::new(store))))
-    }
-    pub fn new(path: impl AsRef<Path>) -> anyhow::Result<Self> {
-        let store = BlockStore::open(path, Config::default())?;
+    pub fn new(store: BlockStore) -> anyhow::Result<Self> {
         Ok(SqliteStore(Arc::new(Mutex::new(store))))
     }
 }

--- a/banyan-cli/src/tag_index.rs
+++ b/banyan-cli/src/tag_index.rs
@@ -1,8 +1,5 @@
 use libipld::{
-    cbor::{
-        decode::read_u8,
-        DagCborCodec,
-    },
+    cbor::{decode::read_u8, DagCborCodec},
     codec::{Decode, Encode},
 };
 use maplit::btreeset;

--- a/banyan-cli/src/tag_index.rs
+++ b/banyan-cli/src/tag_index.rs
@@ -101,6 +101,7 @@ pub fn map_to_index_set(table: &TagSet, tags: &TagSet) -> Option<IndexSet> {
         .collect::<Option<_>>()
 }
 
+#[allow(dead_code)]
 impl TagIndex {
     /// given a query expression in Dnf form, returns all matching indices
     pub fn matching(&self, query: Dnf) -> Vec<usize> {
@@ -215,6 +216,7 @@ impl From<Dnf> for Expression {
     }
 }
 
+#[allow(dead_code)]
 impl Expression {
     pub fn literal(text: SmolStr) -> Self {
         Self::Literal(text)

--- a/banyan-cli/src/tags.rs
+++ b/banyan-cli/src/tags.rs
@@ -129,6 +129,7 @@ impl TimeData {
     }
 }
 
+#[allow(dead_code)]
 impl Key {
     pub fn single(lamport: u64, time: u64, tags: TagSet) -> Self {
         Self {
@@ -172,6 +173,7 @@ impl Key {
     }
 }
 
+#[allow(dead_code)]
 impl Key {
     fn combine(&mut self, b: &Self) {
         self.time.combine(&b.time);
@@ -182,6 +184,7 @@ impl Key {
 #[derive(Debug)]
 pub struct DnfQuery(pub Vec<Key>);
 
+#[allow(dead_code)]
 impl DnfQuery {
     fn intersects(&self, v: &Key) -> bool {
         self.0.iter().any(|x| x.intersects(v))

--- a/banyan/src/forest/read.rs
+++ b/banyan/src/forest/read.rs
@@ -484,6 +484,7 @@ where
                     index.sealed,
                 );
             }
+
             NodeInfo::Branch(index, branch) => {
                 println!(
                     "{}Branch(count={}, key_bytes={}, value_bytes={}, sealed={})",

--- a/banyan/src/forest/stream.rs
+++ b/banyan/src/forest/stream.rs
@@ -121,7 +121,7 @@ impl<
                         // abort at the first non-ok offset
                         result.is_ok()
                     });
-                iter.to_stream(1, thread_pool.clone())
+                iter.into_stream(1, thread_pool.clone())
             })
     }
 

--- a/banyan/src/index.rs
+++ b/banyan/src/index.rs
@@ -105,7 +105,7 @@ pub struct LeafIndex<T: TreeTypes> {
     // link to the block containing the values
     pub link: Option<T::Link>,
     /// A sequence of keys with the same number of values as the data block the link points to.
-    pub keys: T::KeySeq,
+    pub keys: T::KeySeq, // query??? --> keys[3]
     // serialized size of the data
     pub value_bytes: u64,
 }
@@ -133,16 +133,16 @@ impl<T: TreeTypes> LeafIndex<T> {
 /// index for a branch node, containing summary data for its children
 #[derive(Debug, DagCbor)]
 pub struct BranchIndex<T: TreeTypes> {
-    // number of events
+    // number of items
     pub count: u64,
     // level of the tree node
     pub level: u32,
     // block is sealed
     pub sealed: bool,
     // link to the branch node
-    pub link: Option<T::Link>,
+    pub link: Option<T::Link>, // resolves to Vec<Index<T>>
     // extra data
-    pub summaries: T::SummarySeq,
+    pub summaries: T::SummarySeq, // Query???? --> link[2] --> Index<T>
     // accumulated serialized size of all values in this tree
     pub value_bytes: u64,
     // accumulated serialized size of all keys and summaries in this tree
@@ -313,8 +313,8 @@ impl AsRef<ZstdDagCborSeq> for Leaf {
     }
 }
 
-/// enum that combines index and corrsponding data
-pub(crate) enum NodeInfo<'a, T: TreeTypes> {
+/// enum that combines index and corresponding data
+pub enum NodeInfo<'a, T: TreeTypes> {
     // Branch with index and data
     Branch(&'a BranchIndex<T>, Branch<T>),
     /// Leaf with index and data

--- a/banyan/src/index.rs
+++ b/banyan/src/index.rs
@@ -105,7 +105,7 @@ pub struct LeafIndex<T: TreeTypes> {
     // link to the block containing the values
     pub link: Option<T::Link>,
     /// A sequence of keys with the same number of values as the data block the link points to.
-    pub keys: T::KeySeq, // query??? --> keys[3]
+    pub keys: T::KeySeq,
     // serialized size of the data
     pub value_bytes: u64,
 }
@@ -140,9 +140,9 @@ pub struct BranchIndex<T: TreeTypes> {
     // block is sealed
     pub sealed: bool,
     // link to the branch node
-    pub link: Option<T::Link>, // resolves to Vec<Index<T>>
+    pub link: Option<T::Link>,
     // extra data
-    pub summaries: T::SummarySeq, // Query???? --> link[2] --> Index<T>
+    pub summaries: T::SummarySeq,
     // accumulated serialized size of all values in this tree
     pub value_bytes: u64,
     // accumulated serialized size of all keys and summaries in this tree

--- a/banyan/src/tree.rs
+++ b/banyan/src/tree.rs
@@ -59,6 +59,9 @@ impl<T: TreeTypes> Clone for Tree<T> {
     }
 }
 
+pub type GraphEdges = Vec<(usize, usize)>;
+pub type GraphNodes<S> = BTreeMap<usize, S>;
+
 impl<
         T: TreeTypes,
         V: DagCbor + Clone + Send + Sync + Debug + 'static,
@@ -84,7 +87,7 @@ impl<
         &self,
         tree: &Tree<T>,
         f: impl Fn((usize, &NodeInfo<T>)) -> S + Clone,
-    ) -> Result<(Vec<(usize, usize)>, BTreeMap<usize, S>)> {
+    ) -> Result<(GraphEdges, GraphNodes<S>)> {
         match &tree.root {
             Some(index) => self.dump_graph0(None, 0, index, f),
             None => anyhow::bail!("Tree must not be empty"),
@@ -97,7 +100,7 @@ impl<
         next_id: usize,
         index: &Index<T>,
         f: impl Fn((usize, &NodeInfo<T>)) -> S + Clone,
-    ) -> Result<(Vec<(usize, usize)>, BTreeMap<usize, S>)> {
+    ) -> Result<(GraphEdges, GraphNodes<S>)> {
         let mut edges = vec![];
         let mut nodes: BTreeMap<usize, S> = Default::default();
 

--- a/banyan/src/util.rs
+++ b/banyan/src/util.rs
@@ -80,6 +80,7 @@ where
     Self: 'static + Sized + Send,
     Self::Item: Send,
 {
+    #[allow(clippy::clippy::wrong_self_convention)]
     fn to_stream(self, buffer_size: usize, thread_pool: ThreadPool) -> mpsc::Receiver<Self::Item> {
         let (mut sender, receiver) = mpsc::channel(buffer_size);
 

--- a/banyan/src/util.rs
+++ b/banyan/src/util.rs
@@ -80,8 +80,11 @@ where
     Self: 'static + Sized + Send,
     Self::Item: Send,
 {
-    #[allow(clippy::clippy::wrong_self_convention)]
-    fn to_stream(self, buffer_size: usize, thread_pool: ThreadPool) -> mpsc::Receiver<Self::Item> {
+    fn into_stream(
+        self,
+        buffer_size: usize,
+        thread_pool: ThreadPool,
+    ) -> mpsc::Receiver<Self::Item> {
         let (mut sender, receiver) = mpsc::channel(buffer_size);
 
         thread_pool.spawn_ok(async move {

--- a/banyan/src/zstd_dag_cbor_seq.rs
+++ b/banyan/src/zstd_dag_cbor_seq.rs
@@ -71,7 +71,7 @@ impl ZstdDagCborSeq {
         // call finish to write the zstd frame
         let data = encoder.finish()?;
         // box into an arc
-        Ok(Self::new(data.into(), links.into_iter().collect()))
+        Ok(Self::new(data, links.into_iter().collect()))
     }
 
     /// create ZStdArray from a single serializable item
@@ -114,7 +114,7 @@ impl ZstdDagCborSeq {
             // the first ? is to handle the io error from decompress_and_transform, the second to handle the inner io error from write_all
             let (size, data) =
                 decompress_and_transform(compressed, &mut |decompressed| -> anyhow::Result<()> {
-                    scrape_links(decompressed.as_ref(), &mut links)?;
+                    scrape_links(decompressed, &mut links)?;
                     encoder.write_all(decompressed)?;
                     Ok(())
                 })?;
@@ -164,7 +164,7 @@ impl ZstdDagCborSeq {
         full |= data.len() >= compressed_size;
         full |= keys.len() >= max_keys;
         full |= size >= uncompressed_size;
-        Ok((Self::new(data.into(), links.into_iter().collect()), full))
+        Ok((Self::new(data, links.into_iter().collect()), full))
     }
 
     /// Get the compressed data
@@ -305,7 +305,7 @@ fn shrink_to_fit(slice: &[bool]) -> &[bool] {
             return &slice[0..=i];
         }
     }
-    return &[];
+    &[]
 }
 
 impl fmt::Debug for ZstdDagCborSeq {
@@ -519,7 +519,7 @@ mod tests {
             let data1: Vec<u32> = DagCborCodec.decode(&decompressed)?;
             assert_eq!(data1, data);
         } else {
-            assert!(false);
+            panic!();
         }
         Ok(())
     }

--- a/banyan/tests/build_check.rs
+++ b/banyan/tests/build_check.rs
@@ -386,7 +386,7 @@ async fn build_converges(data: Vec<u32>) -> bool {
 // parses hex from cbor.me format
 fn from_cbor_me(text: &str) -> anyhow::Result<Vec<u8>> {
     let parts = text
-        .split("\n")
+        .split('\n')
         .filter_map(|x| x.split('#').next())
         .flat_map(|x| x.split_whitespace())
         .collect::<String>();

--- a/banyan/tests/link_scraping.rs
+++ b/banyan/tests/link_scraping.rs
@@ -109,7 +109,7 @@ fn links_get_properly_scraped(xs: Vec<(Key, Payload)>) -> anyhow::Result<bool> {
 
 quickcheck! {
     fn tree_link_scraping(xs: Vec<(Key, Payload)>) -> anyhow::Result<bool> {
-        links_get_properly_scraped(xs.clone())
+        links_get_properly_scraped(xs)
     }
 }
 


### PR DESCRIPTION
First chunk of changes coming, so that this doesn't grow too big:
* Clap --> structopt
* configurable storage (sqlite, memory, ipfs http)
* made clippy happy
* added cargo fmt and clippy checks to ci
* `banyan-cli graph` gives dot output:
```
banyan-cli --storage my_db.sqlite graph --root bafyreibjfoo7hooyhf7oyvq67cb2p7spli374d3oo3oycbb7rbkcnk5hhi | graphviz -Tpng > output.png
```
yields
![image](https://user-images.githubusercontent.com/7816612/110851023-cbcd0c80-82b0-11eb-9089-54d1166e5868.png)
(grey is sealed)

or a bit bigger:

![image](https://user-images.githubusercontent.com/7816612/110851116-eacb9e80-82b0-11eb-9a7b-fe8e7a0b9af3.png)


**they really do look like banyan trees!**