### PR TITLE
Fix retain bug

### DIFF
--- a/banyan/src/forest/read.rs
+++ b/banyan/src/forest/read.rs
@@ -1,8 +1,7 @@
 use super::{BranchCache, Config, CryptoConfig, FilteredChunk, Forest, TreeTypes};
 use crate::{
     index::{
-        deserialize_compressed, Branch, BranchIndex, CompactSeq, Index, IndexRef, Leaf, LeafIndex,
-        NodeInfo,
+        deserialize_compressed, Branch, BranchIndex, CompactSeq, Index, IndexRef, Leaf, NodeInfo,
     },
     query::Query,
     store::ReadOnlyStore,

--- a/banyan/src/forest/write.rs
+++ b/banyan/src/forest/write.rs
@@ -337,9 +337,18 @@ where
         index: &Index<T>,
         level: &mut i32,
     ) -> Result<Index<T>> {
-        if !index.sealed() {
-            *level = (*level).min((index.level() as i32) - 1);
+        if index.sealed() && index.level() as i32 <= *level {
+            // this node is sealed and below the level, so we can proceed.
+            // but we must still set the level so we can not go "up" again.
+            *level = index.level() as i32;
+        } else {
+            // this node might be either non-sealed, or we went "up",
+            // so we must exclude the current level
+            *level = (*level).min(index.level() as i32 - 1);
         }
+        // if !index.sealed() {
+        //     *level = (*level).min((index.level() as i32) - 1);
+        // }
         match index {
             Index::Branch(index) => {
                 let mut index = index.clone();

--- a/banyan/src/forest/write.rs
+++ b/banyan/src/forest/write.rs
@@ -354,7 +354,12 @@ where
                     index.link = None;
                 }
                 // this will only be executed unless we are already purged
-                if let Some(node) = self.load_branch(&index)? {
+                if let Some(node) = index
+                    .link
+                    .as_ref()
+                    .map(|link| self.load_branch(link))
+                    .transpose()?
+                {
                     let mut children = node.children.to_vec();
                     let mut changed = false;
                     let offsets = zip_with_offset_ref(node.children.iter(), offset);
@@ -402,7 +407,11 @@ where
         match index {
             Index::Branch(index) => {
                 // important not to hit the cache here!
-                let branch = self.load_branch(index);
+                let branch = index
+                    .link
+                    .as_ref()
+                    .map(|link| self.load_branch(link))
+                    .transpose();
                 let mut index = index.clone();
                 match branch {
                     Ok(Some(node)) => {
@@ -440,7 +449,12 @@ where
             Index::Leaf(index) => {
                 let mut index = index.clone();
                 // important not to hit the cache here!
-                if let Err(cause) = self.load_leaf(&index) {
+                if let Err(cause) = index
+                    .link
+                    .as_ref()
+                    .map(|link| self.load_leaf(link))
+                    .transpose()
+                {
                     let link_txt = index.link.map(|x| x.to_string()).unwrap_or_default();
                     report.push(format!("forgetting leaf {} due to {}", link_txt, cause));
                     if !index.sealed {

--- a/banyan/src/forest/write.rs
+++ b/banyan/src/forest/write.rs
@@ -212,7 +212,7 @@ where
         } else {
             self.leaf_from_iter(from)?.into()
         };
-        while from.peek().is_some() && node.level() < level {
+        while (from.peek().is_some() || node.level() == 0) && node.level() < level {
             let level = node.level() + 1;
             node = self
                 .extend_branch(vec![node], level, from, CreateMode::Packed)?

--- a/banyan/src/tree.rs
+++ b/banyan/src/tree.rs
@@ -171,7 +171,12 @@ impl<
     /// leftmost branches of the tree as separate trees
     fn left_roots0(&self, index: &Index<T>) -> Result<Vec<Index<T>>> {
         let mut result = if let Index::Branch(branch) = index {
-            if let Some(branch) = self.load_branch_cached(branch)? {
+            if let Some(branch) = branch
+                .link
+                .as_ref()
+                .map(|link| self.load_branch_cached(link))
+                .transpose()?
+            {
                 self.left_roots0(branch.first_child())?
             } else {
                 Vec::new()

--- a/banyan/tests/build_check.rs
+++ b/banyan/tests/build_check.rs
@@ -428,6 +428,69 @@ fn retain1() -> anyhow::Result<()> {
 }
 
 #[test]
+fn retain2() -> anyhow::Result<()> {
+    let xs = vec![
+        vec![
+            (Key(0), 0),
+            (Key(1), 0),
+            (Key(2), 0),
+            (Key(3), 0),
+            (Key(4), 0),
+            (Key(5), 0),
+            (Key(6), 0),
+            (Key(7), 0),
+            (Key(8), 0),
+            (Key(9), 0),
+        ],
+        vec![
+            (Key(0), 0),
+            (Key(1), 0),
+            (Key(2), 0),
+            (Key(3), 0),
+            (Key(4), 0),
+            (Key(5), 0),
+            (Key(6), 0),
+            (Key(7), 0),
+            (Key(8), 0),
+            (Key(9), 0),
+            (Key(10), 0),
+            (Key(11), 0),
+            (Key(12), 0),
+            (Key(13), 0),
+            (Key(14), 0),
+            (Key(15), 0),
+            (Key(16), 0),
+            (Key(17), 0),
+            (Key(18), 0),
+            (Key(19), 0),
+            (Key(20), 0),
+            (Key(21), 0),
+            (Key(22), 0),
+            (Key(23), 0),
+            (Key(24), 0),
+            (Key(25), 0),
+            (Key(26), 0),
+            (Key(27), 0),
+            (Key(28), 0),
+            (Key(29), 0),
+            (Key(30), 0),
+            (Key(31), 0),
+            (Key(32), 0),
+            (Key(33), 0),
+            (Key(34), 0),
+            (Key(35), 0),
+            (Key(36), 0),
+            (Key(37), 0),
+            (Key(38), 0),
+            (Key(39), 0),
+        ],
+    ];
+    let ok = do_retain(xs)?;
+    assert!(ok);
+    Ok(())
+}
+
+#[test]
 fn build1() -> anyhow::Result<()> {
     let xs = (0..10).map(|i| (Key(i), i)).collect::<Vec<_>>();
     let store = MemStore::new(usize::max_value(), Sha256Digest::digest);


### PR DESCRIPTION
There was a bug in retain that caused stuff in the non-fixed part of the tree to be collected.

Basically, it was only looking at the sealed flag. But there are situations where you have sealed nodes that do not belong to the sealed part of the tree.

Retain does the right thing now, and does not consider sealed nodes that have a higher level as previous nodes.