### PR TITLE
Reduce tracing noise

### DIFF
--- a/banyan/src/forest/write.rs
+++ b/banyan/src/forest/write.rs
@@ -346,9 +346,6 @@ where
             // so we must exclude the current level
             *level = (*level).min(index.level() as i32 - 1);
         }
-        // if !index.sealed() {
-        //     *level = (*level).min((index.level() as i32) - 1);
-        // }
         match index {
             Index::Branch(index) => {
                 let mut index = index.clone();

--- a/banyan/src/forest/write.rs
+++ b/banyan/src/forest/write.rs
@@ -337,9 +337,18 @@ where
         index: &Index<T>,
         level: &mut i32,
     ) -> Result<Index<T>> {
-        if !index.sealed() {
-            *level = (*level).min((index.level() as i32) - 1);
+        if index.sealed() && index.level() as i32 <= *level {
+            // this node is sealed and below the level, so we can proceed.
+            // but we must still set the level so we can not go "up" again.
+            *level = index.level() as i32;
+        } else {
+            // this node might be either non-sealed, or we went "up",
+            // so we must exclude the current level
+            *level = (*level).min(index.level() as i32 - 1);
         }
+        // if !index.sealed() {
+        //     *level = (*level).min((index.level() as i32) - 1);
+        // }
         match index {
             Index::Branch(index) => {
                 let mut index = index.clone();

--- a/banyan/src/forest/write.rs
+++ b/banyan/src/forest/write.rs
@@ -212,7 +212,7 @@ where
         } else {
             self.leaf_from_iter(from)?.into()
         };
-        while from.peek().is_some() && node.level() < level {
+        while (from.peek().is_some() || node.level() == 0) && node.level() < level {
             let level = node.level() + 1;
             node = self
                 .extend_branch(vec![node], level, from, CreateMode::Packed)?

--- a/banyan/tests/build_check.rs
+++ b/banyan/tests/build_check.rs
@@ -428,6 +428,69 @@ fn retain1() -> anyhow::Result<()> {
 }
 
 #[test]
+fn retain2() -> anyhow::Result<()> {
+    let xs = vec![
+        vec![
+            (Key(0), 0),
+            (Key(1), 0),
+            (Key(2), 0),
+            (Key(3), 0),
+            (Key(4), 0),
+            (Key(5), 0),
+            (Key(6), 0),
+            (Key(7), 0),
+            (Key(8), 0),
+            (Key(9), 0),
+        ],
+        vec![
+            (Key(0), 0),
+            (Key(1), 0),
+            (Key(2), 0),
+            (Key(3), 0),
+            (Key(4), 0),
+            (Key(5), 0),
+            (Key(6), 0),
+            (Key(7), 0),
+            (Key(8), 0),
+            (Key(9), 0),
+            (Key(10), 0),
+            (Key(11), 0),
+            (Key(12), 0),
+            (Key(13), 0),
+            (Key(14), 0),
+            (Key(15), 0),
+            (Key(16), 0),
+            (Key(17), 0),
+            (Key(18), 0),
+            (Key(19), 0),
+            (Key(20), 0),
+            (Key(21), 0),
+            (Key(22), 0),
+            (Key(23), 0),
+            (Key(24), 0),
+            (Key(25), 0),
+            (Key(26), 0),
+            (Key(27), 0),
+            (Key(28), 0),
+            (Key(29), 0),
+            (Key(30), 0),
+            (Key(31), 0),
+            (Key(32), 0),
+            (Key(33), 0),
+            (Key(34), 0),
+            (Key(35), 0),
+            (Key(36), 0),
+            (Key(37), 0),
+            (Key(38), 0),
+            (Key(39), 0),
+        ],
+    ];
+    let ok = do_retain(xs)?;
+    assert!(ok);
+    Ok(())
+}
+
+#[test]
 fn build1() -> anyhow::Result<()> {
     let xs = (0..10).map(|i| (Key(i), i)).collect::<Vec<_>>();
     let store = MemStore::new(usize::max_value(), Sha256Digest::digest);


### PR DESCRIPTION
Set tracing level for node creation from info to debug.

Also, always use the tracing:: prefix to make it more easily greppable...