### PR TITLE
Update deps.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,9 +35,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afddf7f520a80dbf76e6f50a35bca42a2331ef227a28b3b6dc5c2e2338d114b1"
+checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
 
 [[package]]
 name = "arrayref"
@@ -320,6 +320,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
 name = "cpuid-bool"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -363,10 +369,11 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.11"
+version = "0.99.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cb0e6161ad61ed084a36ba71fbba9e3ac5aee3606fb607fe08da6acbcf3d8c"
+checksum = "f82b1b72f1263f214c0f823371768776c4f5841b942c9883aa8e5ec584fd0ba6"
 dependencies = [
+ "convert_case",
  "proc-macro2",
  "quote",
  "syn",
@@ -457,9 +464,9 @@ checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
 
 [[package]]
 name = "futures"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f55667319111d593ba876406af7c409c0ebb44dc4be6132a783ccf163ea14c1"
+checksum = "a9d5813545e459ad3ca1bff9915e9ad7f1a47dc6a91b627ce321d5863b7dd253"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -472,9 +479,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c2dd2df839b57db9ab69c2c9d8f3e8c81984781937fe2807dc6dcf3b2ad2939"
+checksum = "ce79c6a52a299137a6013061e0cf0e688fce5d7f1bc60125f520912fdb29ec25"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -482,15 +489,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15496a72fabf0e62bdc3df11a59a3787429221dd0710ba8ef163d6f7a9112c94"
+checksum = "098cd1c6dda6ca01650f1a37a794245eb73181d0d4d4e955e2f3c37db7af1815"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891a4b7b96d84d5940084b2a37632dd65deeae662c114ceaa2c879629c9c0ad1"
+checksum = "10f6cb7042eda00f0049b1d2080aa4b93442997ee507eb3828e8bd7577f94c9d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -500,15 +507,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71c2c65c57704c32f5241c1223167c2c3294fd34ac020c807ddbe6db287ba59"
+checksum = "365a1a1fb30ea1c03a830fdb2158f5236833ac81fa0ad12fe35b29cddc35cb04"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea405816a5139fb39af82c2beb921d52143f556038378d6db21183a5c37fbfb7"
+checksum = "668c6733a182cd7deb4f1de7ba3bf2120823835b3bcfbeacf7d2c4a773c1bb8b"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
@@ -518,21 +525,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85754d98985841b7d4f5e8e6fbfa4a4ac847916893ec511a2917ccd8525b8bb3"
+checksum = "5c5629433c555de3d82861a7a4e3794a4c40040390907cfbfd7143a92a426c23"
 
 [[package]]
 name = "futures-task"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa189ef211c15ee602667a6fcfe1c1fd9e07d42250d2156382820fba33c9df80"
+checksum = "ba7aa51095076f3ba6d9a1f702f74bd05ec65f555d70d2033d55ba8d69f581bc"
 
 [[package]]
 name = "futures-util"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1812c7ab8aedf8d6f2701a43e1243acdbcc2b36ab26e2ad421eb99ac963d96d1"
+checksum = "3c144ad54d60f23927f0a6b6d816e4271278b64f005ad65e4e35291d2de9c025"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -725,9 +732,9 @@ dependencies = [
 
 [[package]]
 name = "ipfs-sqlite-block-store"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0899665fbf8bea55eaaddfc8ef3a591481f13f8b0f3ef1a11372ce31305aefbd"
+checksum = "8d85467d8dad270f292a9e31b1135d7fd15795bb27792fd751f88bac2cc93530"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -911,9 +918,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.20.1"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64d31059f22935e6c31830db5249ba2b7ecd54fd73a9909286f0a67aa55c2fbd"
+checksum = "19cb1effde5f834799ac5e5ef0e40d45027cd74f271b1de786ba8abb30e2164d"
 dependencies = [
  "cc",
  "pkg-config",
@@ -1453,9 +1460,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf12057f289428dbf5c591c74bf10392e4a8003f993405a902f20117019022d4"
+checksum = "2296f2fac53979e8ccbc4a1136b25dcefd37be9ed7e4a1f6b05a6029c84ff124"
 dependencies = [
  "base64",
  "bytes",
@@ -1502,9 +1509,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.24.2"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5f38ee71cbab2c827ec0ac24e76f82eca723cee92c509a65f67dee393c25112"
+checksum = "fbc783b7ddae608338003bac1fa00b6786a75a9675fbd8e87243ecfdea3f6ed2"
 dependencies = [
  "bitflags",
  "fallible-iterator",
@@ -1561,18 +1568,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.124"
+version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd761ff957cb2a45fbb9ab3da6512de9de55872866160b23c25f1a841e99d29f"
+checksum = "558dc50e1a5a5fa7112ca2ce4effcb321b0300c0d4ccf0776a9f60cd89031171"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.124"
+version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1800f7693e94e186f5e25a28291ae1570da908aff7d97a095dec1e56ff99069b"
+checksum = "b093b7a2bb58203b5da3056c05b4ec1fed827dcfdb37347a8841695263b3d06d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1826,9 +1833,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.3.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d56477f6ed99e10225f38f9f75f872f29b8b8bd8c0b946f63345bb144e9eeda"
+checksum = "83f0c8e7c0addab50b663055baf787d0af7f413a46e6e7fb9559a4e4db7137a5"
 dependencies = [
  "autocfg",
  "bytes",
@@ -1939,9 +1946,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ab8966ac3ca27126141f7999361cc97dd6fb4b71da04c02044fa9045d98bb96"
+checksum = "705096c6f83bf68ea5d357a6aa01829ddbdac531b357b45abeca842938085baa"
 dependencies = [
  "ansi_term 0.12.1",
  "chrono",
@@ -2176,9 +2183,9 @@ dependencies = [
 
 [[package]]
 name = "weight-cache"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6792d56b6593d433d9f75e690889c6a6297a42c8049da329e4d865f5de3b83c6"
+checksum = "5a6f50193a6f298172bed8afcbd853d5707a161222a2a673a7fb801806fb7201"
 dependencies = [
  "linked-hash-map",
 ]
@@ -2235,18 +2242,18 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.6.1+zstd.1.4.9"
+version = "0.7.0+zstd.1.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de55e77f798f205d8561b8fe2ef57abfb6e0ff2abe7fd3c089e119cdb5631a3"
+checksum = "9428752481d8372e15b1bf779ea518a179ad6c771cca2d2c60e4fbff3cc2cd52"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "3.0.1+zstd.1.4.9"
+version = "3.1.0+zstd.1.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1387cabcd938127b30ce78c4bf00b30387dddf704e3f0881dbc4ff62b5566f8c"
+checksum = "5aa1926623ad7fe406e090555387daf73db555b948134b4d73eac5eb08fb666d"
 dependencies = [
  "libc",
  "zstd-sys",
@@ -2254,9 +2261,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "1.4.20+zstd.1.4.9"
+version = "1.5.0+zstd.1.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebd5b733d7cf2d9447e2c3e76a5589b4f5e5ae065c22a2bc0b023cbc331b6c8e"
+checksum = "4e6c094340240369025fc6b731b054ee2a834328fa584310ac96aa4baebdc465"
 dependencies = [
  "cc",
  "libc",

--- a/banyan-utils/Cargo.toml
+++ b/banyan-utils/Cargo.toml
@@ -17,37 +17,37 @@ name = "banyan-cli"
 path = "src/bin/cli.rs"
 
 [dependencies]
-anyhow = "1.0.38"
+anyhow = "1.0.40"
 banyan = { version = "0.9.1", path = "../banyan" }
 base64 = "0.13.0"
-derive_more = "0.99.11"
+derive_more = "0.99.13"
 dot = "0.1.4"
-env_logger = "0.8.2"
-futures = "0.3.12"
-hex = "0.4.2"
-ipfs-sqlite-block-store = "0.3.0"
+env_logger = "0.8.3"
+futures = "0.3.14"
+hex = "0.4.3"
+ipfs-sqlite-block-store = "0.5.0"
 libipld = { version = "0.11.0", features = ["unleashed"] }
-lru = "0.6.4"
+lru = "0.6.5"
 maplit = "1.0.2"
 multihash = "0.13.2"
 parking_lot = "0.11.1"
 percent-encoding = "2.1.0"
 rand = "0.8.3"
 reduce = "0.1.4"
-reqwest = { version = "0.11.0", default-features = false, features = ["blocking", "json", "multipart", "rustls", "stream"] }
+reqwest = { version = "0.11.3", default-features = false, features = ["blocking", "json", "multipart", "rustls", "stream"] }
 salsa20 = "0.7.2"
-serde = { version = "1.0.123", features = ["derive", "rc"] }
-serde_json = "1.0.62"
+serde = { version = "1.0.125", features = ["derive", "rc"] }
+serde_json = "1.0.64"
 smol_str = { version = "0.1.17", features = ["serde"] }
 structopt = "0.3.21"
-tokio = { version = "1.2.0", features = ["full"] }
-tracing = "0.1.23"
-tracing-subscriber = "0.2.15"
+tokio = { version = "1.5.0", features = ["full"] }
+tracing = "0.1.25"
+tracing-subscriber = "0.2.17"
 vec-collections = "0.3.5"
-zstd = "0.6.0"
+zstd = "0.7.0"
 
 [dev-dependencies]
 quickcheck = "1.0.3"
 
-[target.'cfg(target_env = "musl")'.dependencies.jemallocator]
-version = "0.3.2"
+[target.'cfg(target_env = "musl")'.dependencies]
+jemallocator = "0.3.2"

--- a/banyan-utils/src/bin/cli.rs
+++ b/banyan-utils/src/bin/cli.rs
@@ -20,6 +20,7 @@ use banyan_utils::{
     tag_index::{Tag, TagSet},
     tags::{DnfQuery, Key, Sha256Digest, TT},
 };
+use libipld::DefaultParams;
 
 #[cfg(target_env = "musl")]
 #[global_allocator]
@@ -33,7 +34,7 @@ type Txn = Transaction<TT, String, ArcReadOnlyStore<Sha256Digest>, ArcBlockWrite
 enum Storage {
     Memory(MemStore<Sha256Digest>),
     Ipfs(IpfsStore),
-    Sqlite(SqliteStore),
+    Sqlite(SqliteStore<DefaultParams>),
 }
 impl ReadOnlyStore<Sha256Digest> for Storage {
     fn get(&self, link: &Sha256Digest) -> Result<Box<[u8]>> {

--- a/banyan-utils/src/sqlite.rs
+++ b/banyan-utils/src/sqlite.rs
@@ -1,23 +1,26 @@
 //! helper methods to work with ipfs/ipld
 use anyhow::{anyhow, Result};
 use banyan::store::{BlockWriter, ReadOnlyStore};
-use ipfs_sqlite_block_store::{BlockStore, OwnedBlock};
-use libipld::Cid;
+use ipfs_sqlite_block_store::BlockStore;
+use libipld::{codec::References, store::StoreParams, Block, Cid, Ipld};
 use parking_lot::Mutex;
 use std::sync::Arc;
 
 use crate::tags::Sha256Digest;
 
 #[derive(Clone)]
-pub struct SqliteStore(Arc<Mutex<BlockStore>>);
+pub struct SqliteStore<S: StoreParams>(Arc<Mutex<BlockStore<S>>>);
 
-impl SqliteStore {
-    pub fn new(store: BlockStore) -> anyhow::Result<Self> {
+impl<S: StoreParams> SqliteStore<S> {
+    pub fn new(store: BlockStore<S>) -> anyhow::Result<Self> {
         Ok(SqliteStore(Arc::new(Mutex::new(store))))
     }
 }
 
-impl ReadOnlyStore<Sha256Digest> for SqliteStore {
+impl<S: StoreParams> ReadOnlyStore<Sha256Digest> for SqliteStore<S>
+where
+    Ipld: References<S::Codecs>,
+{
     fn get(&self, link: &Sha256Digest) -> Result<Box<[u8]>> {
         let cid = Cid::from(*link);
         let block = self.0.lock().get_block(&cid)?;
@@ -29,11 +32,14 @@ impl ReadOnlyStore<Sha256Digest> for SqliteStore {
     }
 }
 
-impl BlockWriter<Sha256Digest> for SqliteStore {
+impl<S: StoreParams> BlockWriter<Sha256Digest> for SqliteStore<S>
+where
+    Ipld: References<S::Codecs>,
+{
     fn put(&self, data: Vec<u8>) -> Result<Sha256Digest> {
         let digest = Sha256Digest::new(&data);
         let cid = digest.into();
-        let block = OwnedBlock::new(cid, data);
+        let block = Block::new_unchecked(cid, data);
         self.0.lock().put_block(&block, None)?;
         Ok(digest)
     }

--- a/banyan/Cargo.toml
+++ b/banyan/Cargo.toml
@@ -10,30 +10,30 @@ description = "Persistent indexable tree data structure"
 repository = "https://github.com/actyx/banyan/"
 
 [dependencies]
-anyhow = "1.0.38"
-derive_more = "0.99.11"
+anyhow = "1.0.40"
+derive_more = "0.99.13"
 fnv = "1.0.7"
-futures = { version = "0.3.12", features = ["thread-pool"] }
+futures = { version = "0.3.14", features = ["thread-pool"] }
 libipld = { version = "0.11.0", features = ["unleashed"] }
 maplit = "1.0.2"
 parking_lot = "0.11.1"
 rand = "0.8.3"
 salsa20 = "0.7.2"
 smallvec = "1.6.1"
-tracing = "0.1.23"
-weight-cache = { version = "0.2.1" }
-zstd = "0.6.0"
+tracing = "0.1.25"
+weight-cache = "0.2.3"
+zstd = "0.7.0"
 
 [dev-dependencies]
 clap = "2.33.3"
-env_logger = "0.8.2"
+env_logger = "0.8.3"
 generic-array = "0.14.4"
-hex = "0.4.2"
+hex = "0.4.3"
 multihash = "0.13.2"
 quickcheck = "1.0.3"
 quickcheck_async = "0.1.1"
 quickcheck_macros = "1.0.0"
 rand_chacha = "0.3.0"
 sha2 = "0.9.3"
-tokio = { version = "1.2.0", features = ["full"] }
-tracing-subscriber = "0.2.15"
+tokio = { version = "1.5.0", features = ["full"] }
+tracing-subscriber = "0.2.17"


### PR DESCRIPTION
Needs a minor release because zstd 0.7 is breaking. And because zstd is a c library breaking releases always require a minor release.