### PR TITLE
Rethink types following nonce -> offset change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "banyan"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "chacha20",
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "banyan-utils"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "banyan",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "banyan"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "chacha20",
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "banyan-utils"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "banyan",

--- a/banyan-utils/Cargo.toml
+++ b/banyan-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "banyan-utils"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Rüdiger Klaehn <rklaehn@protonmail.com>", "Actyx AG"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -18,7 +18,7 @@ path = "src/bin/cli.rs"
 
 [dependencies]
 anyhow = "1.0.40"
-banyan = { version = "0.11.0", path = "../banyan" }
+banyan = { version = "0.12.0", path = "../banyan" }
 base64 = "0.13.0"
 chacha20 = "0.7.1"
 derive_more = "0.99.13"

--- a/banyan-utils/Cargo.toml
+++ b/banyan-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "banyan-utils"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Rüdiger Klaehn <rklaehn@protonmail.com>", "Actyx AG"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -18,7 +18,7 @@ path = "src/bin/cli.rs"
 
 [dependencies]
 anyhow = "1.0.40"
-banyan = { version = "0.12.0", path = "../banyan" }
+banyan = { version = "0.13.0", path = "../banyan" }
 base64 = "0.13.0"
 chacha20 = "0.7.1"
 derive_more = "0.99.13"

--- a/banyan-utils/src/bin/cli.rs
+++ b/banyan-utils/src/bin/cli.rs
@@ -402,8 +402,9 @@ async fn main() -> Result<()> {
             let tree = build_tree(&forest, base, batches, count, unbalanced, 1000).await?;
             forest.dump(&tree)?;
             let roots = forest.roots(&tree)?;
+            let mut offset = tree.offset();
             let levels = roots.iter().map(|x| x.level()).collect::<Vec<_>>();
-            let _tree2 = forest.tree_from_roots(roots)?;
+            let _tree2 = forest.tree_from_roots(roots, &mut offset)?;
             println!("{:?}", tree);
             println!("{}", tree);
             println!("{:?}", levels);

--- a/banyan-utils/src/bin/cli.rs
+++ b/banyan-utils/src/bin/cli.rs
@@ -505,16 +505,15 @@ async fn main() -> Result<()> {
         }
         Command::RecvStream { topic } => {
             let secrets = Secrets::default();
-            let config = Config::debug();
-            let s = pubsub_sub(&*topic)?
+            let links = pubsub_sub(&*topic)?
                 .map_err(anyhow::Error::new)
                 .and_then(|data| future::ready(String::from_utf8(data).map_err(anyhow::Error::new)))
                 .and_then(|data| future::ready(Sha256Digest::from_str(&data)));
             let forest2 = forest.clone();
-            let trees = s.filter_map(move |x| {
+            let trees = links.filter_map(move |link| {
                 let forest = forest2.clone();
                 future::ready(
-                    x.and_then(move |link| forest.load_tree(secrets, config, link))
+                    link.and_then(move |link| forest.load_snapshot(secrets, link))
                         .ok(),
                 )
             });

--- a/banyan-utils/src/bin/cli.rs
+++ b/banyan-utils/src/bin/cli.rs
@@ -12,6 +12,7 @@ use banyan::{
     query::{AllQuery, OffsetRangeQuery, QueryExt},
     store::{ArcBlockWriter, ArcReadOnlyStore, BlockWriter, ReadOnlyStore},
     tree::*,
+    StreamBuilder,
 };
 use banyan_utils::{
     create_chacha_key, dump,
@@ -401,14 +402,6 @@ async fn main() -> Result<()> {
                 batches, count, unbalanced
             );
             let tree = build_tree(&forest, base, batches, count, unbalanced, 1000).await?;
-            forest.dump(&tree.snapshot())?;
-            let roots = forest.roots(&tree)?;
-            let mut state = tree.state();
-            let levels = roots.iter().map(|x| x.level()).collect::<Vec<_>>();
-            let _tree2 = forest.tree_from_roots(roots, &mut state)?;
-            println!("{:?}", tree);
-            println!("{}", tree);
-            println!("{:?}", levels);
             forest.dump(&tree.snapshot())?;
         }
         Command::Bench { count } => {

--- a/banyan-utils/src/dump.rs
+++ b/banyan-utils/src/dump.rs
@@ -143,7 +143,7 @@ pub fn dump_json<Link>(
     mut writer: impl std::io::Write,
 ) -> anyhow::Result<()> {
     let bytes = store.get(&hash)?;
-    let (dag_cbor, offset) = ZstdDagCborSeq::decrypt(&bytes, &value_key)?;
+    let (dag_cbor, _) = ZstdDagCborSeq::decrypt(&bytes, &value_key)?;
     let ipld_ast = dag_cbor.items::<libipld::Ipld>()?;
     for x in ipld_ast {
         let json = DagJsonCodec.encode(&x)?;

--- a/banyan-utils/src/dump.rs
+++ b/banyan-utils/src/dump.rs
@@ -143,7 +143,7 @@ pub fn dump_json<Link>(
     mut writer: impl std::io::Write,
 ) -> anyhow::Result<()> {
     let bytes = store.get(&hash)?;
-    let dag_cbor = ZstdDagCborSeq::decrypt(&bytes, &value_key)?;
+    let (dag_cbor, offset) = ZstdDagCborSeq::decrypt(&bytes, &value_key)?;
     let ipld_ast = dag_cbor.items::<libipld::Ipld>()?;
     for x in ipld_ast {
         let json = DagJsonCodec.encode(&x)?;

--- a/banyan-utils/src/tags.rs
+++ b/banyan-utils/src/tags.rs
@@ -331,9 +331,9 @@ impl Summarizable<Key> for KeySeq {
         let tags = self.tags.tags.clone();
         Key {
             time: TimeData {
-                max_time,
-                min_time,
                 min_lamport,
+                min_time,
+                max_time,
             },
             tags,
         }

--- a/banyan/Cargo.toml
+++ b/banyan/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "banyan"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["Rüdiger Klaehn <rklaehn@protonmail.com>", "Actyx AG"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/banyan/Cargo.toml
+++ b/banyan/Cargo.toml
@@ -18,7 +18,6 @@ futures = { version = "0.3.14", features = ["thread-pool"] }
 libipld = { version = "0.11.0", features = ["unleashed"] }
 maplit = "1.0.2"
 parking_lot = "0.11.1"
-rand = "0.8.3"
 smallvec = "1.6.1"
 tracing = "0.1.25"
 weight-cache = "0.2.3"
@@ -37,3 +36,4 @@ rand_chacha = "0.3.0"
 sha2 = "0.9.3"
 tokio = { version = "1.5.0", features = ["full"] }
 tracing-subscriber = "0.2.17"
+rand = "0.8.3"

--- a/banyan/Cargo.toml
+++ b/banyan/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "banyan"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Rüdiger Klaehn <rklaehn@protonmail.com>", "Actyx AG"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/banyan/src/forest/index_iter.rs
+++ b/banyan/src/forest/index_iter.rs
@@ -18,7 +18,7 @@ enum Mode {
 
 pub(crate) struct IndexIter<T: TreeTypes, V, R, Q: Query<T>> {
     forest: Forest<T, V, R>,
-    stream: Secrets,
+    secrets: Secrets,
     offset: u64,
     query: Q,
     stack: SmallVec<[TraverseState<T>; 5]>,
@@ -68,7 +68,7 @@ where
 {
     pub(crate) fn new(
         forest: Forest<T, V, R>,
-        stream: Secrets,
+        secrets: Secrets,
         query: Q,
         index: Arc<Index<T>>,
     ) -> Self {
@@ -77,7 +77,7 @@ where
 
         Self {
             forest,
-            stream,
+            secrets,
             offset: 0,
             query,
             stack,
@@ -86,7 +86,7 @@ where
     }
     pub(crate) fn new_rev(
         forest: Forest<T, V, R>,
-        stream: Secrets,
+        secrets: Secrets,
         query: Q,
         index: Arc<Index<T>>,
     ) -> Self {
@@ -96,7 +96,7 @@ where
 
         Self {
             forest,
-            stream,
+            secrets,
             offset,
             query,
             stack,
@@ -135,7 +135,7 @@ where
                 continue;
             }
 
-            match self.forest.load_node(&self.stream, &head.index) {
+            match self.forest.load_node(&self.secrets, &head.index) {
                 Ok(NodeInfo::Branch(index, branch)) => {
                     if head.filter.is_empty() {
                         // we hit this branch node for the first time. Apply the

--- a/banyan/src/forest/index_iter.rs
+++ b/banyan/src/forest/index_iter.rs
@@ -1,5 +1,9 @@
-use super::{Forest, TreeTypes};
-use crate::{index::{CompactSeq, Index, NodeInfo}, query::Query, store::ReadOnlyStore, tree::StreamBuilderState};
+use super::{Secrets, Forest, TreeTypes};
+use crate::{
+    index::{CompactSeq, Index, NodeInfo},
+    query::Query,
+    store::ReadOnlyStore,
+};
 use anyhow::Result;
 use core::fmt::Debug;
 use libipld::cbor::DagCbor;
@@ -14,7 +18,7 @@ enum Mode {
 
 pub(crate) struct IndexIter<T: TreeTypes, V, R, Q: Query<T>> {
     forest: Forest<T, V, R>,
-    stream: StreamBuilderState,
+    stream: Secrets,
     offset: u64,
     query: Q,
     stack: SmallVec<[TraverseState<T>; 5]>,
@@ -62,7 +66,12 @@ where
     R: ReadOnlyStore<T::Link> + Clone + Send + Sync + 'static,
     Q: Query<T> + Clone + Send + 'static,
 {
-    pub(crate) fn new(forest: Forest<T, V, R>, stream: StreamBuilderState, query: Q, index: Arc<Index<T>>) -> Self {
+    pub(crate) fn new(
+        forest: Forest<T, V, R>,
+        stream: Secrets,
+        query: Q,
+        index: Arc<Index<T>>,
+    ) -> Self {
         let mode = Mode::Forward;
         let stack = smallvec![TraverseState::new(index)];
 
@@ -75,7 +84,12 @@ where
             mode,
         }
     }
-    pub(crate) fn new_rev(forest: Forest<T, V, R>, stream: StreamBuilderState, query: Q, index: Arc<Index<T>>) -> Self {
+    pub(crate) fn new_rev(
+        forest: Forest<T, V, R>,
+        stream: Secrets,
+        query: Q,
+        index: Arc<Index<T>>,
+    ) -> Self {
         let offset = index.count();
         let mode = Mode::Backward;
         let stack = smallvec![TraverseState::new(index)];

--- a/banyan/src/forest/index_iter.rs
+++ b/banyan/src/forest/index_iter.rs
@@ -1,4 +1,4 @@
-use super::{Secrets, Forest, TreeTypes};
+use super::{Forest, Secrets, TreeTypes};
 use crate::{
     index::{CompactSeq, Index, NodeInfo},
     query::Query,

--- a/banyan/src/forest/mod.rs
+++ b/banyan/src/forest/mod.rs
@@ -189,7 +189,7 @@ impl<T: TreeTypes, V, R, W> std::ops::Deref for Transaction<T, V, R, W> {
     }
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Clone)]
 pub struct Secrets {
     /// chacha20 key to decrypt index nodes
     index_key: chacha20::Key,
@@ -223,7 +223,7 @@ impl Default for Secrets {
     }
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Clone)]
 /// Configuration for a forest. Includes settings for when a node is considered full
 pub struct Config {
     /// maximum number of values in a leaf

--- a/banyan/src/forest/mod.rs
+++ b/banyan/src/forest/mod.rs
@@ -120,10 +120,7 @@ impl<TT: TreeTypes, V, R> Clone for Forest<TT, V, R> {
 }
 
 impl<TT: TreeTypes, V, R: Clone> Forest<TT, V, R> {
-    pub fn new(
-        store: R,
-        branch_cache: BranchCache<TT>,
-    ) -> Self {
+    pub fn new(store: R, branch_cache: BranchCache<TT>) -> Self {
         Self(Arc::new(ForestInner {
             store,
             branch_cache,
@@ -137,10 +134,7 @@ impl<TT: TreeTypes, V, R: Clone> Forest<TT, V, R> {
     ) -> Transaction<TT, V, R, W> {
         let (reader, writer) = f(self.0.as_ref().store.clone());
         Transaction {
-            read: Self::new(
-                reader,
-                self.branch_cache.clone(),
-            ),
+            read: Self::new(reader, self.branch_cache.clone()),
             writer,
         }
     }
@@ -196,14 +190,31 @@ impl<T: TreeTypes, V, R, W> std::ops::Deref for Transaction<T, V, R, W> {
 }
 
 #[derive(Debug, Copy, Clone)]
-pub struct CryptoConfig {
+pub struct Secrets {
     /// chacha20 key to decrypt index nodes
-    pub index_key: chacha20::Key,
+    index_key: chacha20::Key,
     /// chacha20 key to decrypt value nodes
-    pub value_key: chacha20::Key,
+    value_key: chacha20::Key,
 }
 
-impl Default for CryptoConfig {
+impl Secrets {
+    pub fn new(index_key: chacha20::Key, value_key: chacha20::Key) -> Self {
+        Self {
+            index_key,
+            value_key,
+        }
+    }
+
+    pub fn index_key(&self) -> &chacha20::Key {
+        &self.index_key
+    }
+
+    pub fn value_key(&self) -> &chacha20::Key {
+        &self.value_key
+    }
+}
+
+impl Default for Secrets {
     fn default() -> Self {
         Self {
             index_key: [0; 32].into(),

--- a/banyan/src/forest/mod.rs
+++ b/banyan/src/forest/mod.rs
@@ -6,7 +6,6 @@ use core::{fmt::Debug, hash::Hash, iter::FromIterator, marker::PhantomData, ops:
 use futures::future::BoxFuture;
 use libipld::cbor::DagCbor;
 use parking_lot::Mutex;
-use rand::RngCore;
 use std::{fmt::Display, num::NonZeroUsize, sync::Arc};
 use weight_cache::{Weighable, WeightCache};
 mod index_iter;
@@ -210,14 +209,6 @@ pub struct CryptoConfig {
     pub index_key: chacha20::Key,
     /// chacha20 key to decrypt value nodes
     pub value_key: chacha20::Key,
-}
-
-impl CryptoConfig {
-    pub fn random_key() -> chacha20::Key {
-        let mut key = [0u8; 32];
-        rand::thread_rng().fill_bytes(&mut key);
-        key.into()
-    }
 }
 
 impl Default for CryptoConfig {

--- a/banyan/src/forest/mod.rs
+++ b/banyan/src/forest/mod.rs
@@ -107,8 +107,6 @@ pub trait TreeTypes: Debug + Send + Sync + Clone + 'static {
 pub struct ForestInner<T: TreeTypes, V, R> {
     pub(crate) store: R,
     pub(crate) branch_cache: BranchCache<T>,
-    pub(crate) crypto_config: CryptoConfig,
-    pub(crate) config: Config,
     pub(crate) _tt: PhantomData<(T, V, R)>,
 }
 
@@ -125,14 +123,10 @@ impl<TT: TreeTypes, V, R: Clone> Forest<TT, V, R> {
     pub fn new(
         store: R,
         branch_cache: BranchCache<TT>,
-        crypto_config: CryptoConfig,
-        config: Config,
     ) -> Self {
         Self(Arc::new(ForestInner {
             store,
             branch_cache,
-            crypto_config,
-            config,
             _tt: PhantomData,
         }))
     }
@@ -146,8 +140,6 @@ impl<TT: TreeTypes, V, R: Clone> Forest<TT, V, R> {
             read: Self::new(
                 reader,
                 self.branch_cache.clone(),
-                self.crypto_config,
-                self.config,
             ),
             writer,
         }

--- a/banyan/src/forest/read.rs
+++ b/banyan/src/forest/read.rs
@@ -313,7 +313,7 @@ where
         })
     }
 
-    pub(crate) fn load_branch_from_link(&self, link: T::Link) -> Result<Index<T>> {
+    pub(crate) fn load_branch_from_link(&self, link: T::Link) -> Result<(Index<T>, u64)> {
         let store = self.store.clone();
         let index_key = self.index_key();
         let bytes = store.get(&link)?;
@@ -333,7 +333,7 @@ where
             key_bytes,
         }
         .into();
-        Ok(result)
+        Ok((result, offset))
     }
 
     /// load a branch given a branch index, from the cache

--- a/banyan/src/forest/read.rs
+++ b/banyan/src/forest/read.rs
@@ -306,7 +306,7 @@ where
     pub(crate) fn load_leaf(&self, index: &LeafIndex<T>) -> Result<Option<Leaf>> {
         Ok(if let Some(link) = &index.link {
             let data = &self.store().get(link)?;
-            let (items, offset) = ZstdDagCborSeq::decrypt(data, &self.value_key())?;
+            let (items, _) = ZstdDagCborSeq::decrypt(data, &self.value_key())?;
             Some(Leaf::new(items))
         } else {
             None
@@ -384,7 +384,7 @@ where
         let t0 = Instant::now();
         let result = Ok(if let Some(link) = &index.link {
             let bytes = self.store.get(&link)?;
-            let (children, offset) = deserialize_compressed(&self.index_key(), &bytes)?;
+            let (children, _) = deserialize_compressed(&self.index_key(), &bytes)?;
             Some(Branch::<T>::new(children))
         } else {
             None

--- a/banyan/src/forest/read.rs
+++ b/banyan/src/forest/read.rs
@@ -1,4 +1,4 @@
-use super::{BranchCache, Config, Secrets, FilteredChunk, Forest, TreeTypes};
+use super::{BranchCache, Config, FilteredChunk, Forest, Secrets, TreeTypes};
 use crate::{
     index::{
         deserialize_compressed, Branch, BranchIndex, CompactSeq, Index, IndexRef, Leaf, LeafIndex,
@@ -309,11 +309,12 @@ where
 
     pub(crate) fn load_branch_from_link(
         &self,
-        stream: &StreamBuilderState,
+        secrets: &Secrets,
+        config: &Config,
         link: T::Link,
     ) -> Result<(Index<T>, u64)> {
         let store = self.store.clone();
-        let index_key = stream.index_key();
+        let index_key = secrets.index_key();
         let bytes = store.get(&link)?;
         let (children, offset) = deserialize_compressed::<T>(index_key, &bytes)?;
         let level = children.iter().map(|x| x.level()).max().unwrap() + 1;
@@ -326,7 +327,7 @@ where
             level,
             count,
             summaries,
-            sealed: stream.config().branch_sealed(&children, level),
+            sealed: config.branch_sealed(&children, level),
             value_bytes,
             key_bytes,
         }

--- a/banyan/src/forest/read.rs
+++ b/banyan/src/forest/read.rs
@@ -295,8 +295,8 @@ where
     pub(crate) fn load_leaf(&self, stream: &Secrets, index: &LeafIndex<T>) -> Result<Option<Leaf>> {
         Ok(if let Some(link) = &index.link {
             let data = &self.store().get(link)?;
-            let (items, _) = ZstdDagCborSeq::decrypt(data, stream.value_key())?;
-            Some(Leaf::new(items))
+            let (items, offset) = ZstdDagCborSeq::decrypt(data, stream.value_key())?;
+            Some(Leaf::new(items, offset))
         } else {
             None
         })
@@ -390,8 +390,8 @@ where
         let t0 = Instant::now();
         let result = Ok(if let Some(link) = &index.link {
             let bytes = self.store.get(&link)?;
-            let (children, _) = deserialize_compressed(secrets.index_key(), &bytes)?;
-            Some(Branch::<T>::new(children))
+            let (children, offset) = deserialize_compressed(secrets.index_key(), &bytes)?;
+            Some(Branch::<T>::new(children, offset))
         } else {
             None
         });

--- a/banyan/src/forest/read.rs
+++ b/banyan/src/forest/read.rs
@@ -293,11 +293,7 @@ where
     }
 
     /// load a leaf given a leaf index
-    pub(crate) fn load_leaf(
-        &self,
-        stream: &Secrets,
-        index: &LeafIndex<T>,
-    ) -> Result<Option<Leaf>> {
+    pub(crate) fn load_leaf(&self, stream: &Secrets, index: &LeafIndex<T>) -> Result<Option<Leaf>> {
         Ok(if let Some(link) = &index.link {
             let data = &self.store().get(link)?;
             let (items, _) = ZstdDagCborSeq::decrypt(data, stream.value_key())?;
@@ -554,12 +550,7 @@ where
         .boxed()
     }
 
-    pub(crate) fn dump0(
-        &self,
-        stream: &Secrets,
-        index: &Index<T>,
-        prefix: &str,
-    ) -> Result<()> {
+    pub(crate) fn dump0(&self, stream: &Secrets, index: &Index<T>, prefix: &str) -> Result<()> {
         match self.load_node(stream, index)? {
             NodeInfo::Branch(index, branch) => {
                 println!(
@@ -584,11 +575,7 @@ where
         Ok(())
     }
 
-    pub(crate) fn roots_impl(
-        &self,
-        stream: &Secrets,
-        index: &Index<T>,
-    ) -> Result<Vec<Index<T>>> {
+    pub(crate) fn roots_impl(&self, stream: &Secrets, index: &Index<T>) -> Result<Vec<Index<T>>> {
         let mut res = Vec::new();
         let mut level: i32 = i32::max_value();
         self.roots0(stream, index, &mut level, &mut res)?;

--- a/banyan/src/forest/stream.rs
+++ b/banyan/src/forest/stream.rs
@@ -2,7 +2,7 @@
 use crate::{
     index::IndexRef,
     store::ReadOnlyStore,
-    tree::Tree,
+    tree::Snapshot,
     util::{take_until_condition, ToStreamExt},
 };
 
@@ -30,7 +30,7 @@ impl<
     ) -> impl Stream<Item = anyhow::Result<(u64, T::Key, V)>> + Send
     where
         Q: Query<T> + Clone + 'static,
-        S: Stream<Item = Tree<T>> + Send + 'static,
+        S: Stream<Item = Snapshot<T>> + Send + 'static,
     {
         self.stream_trees_chunked(query, trees, 0..=u64::max_value(), &|_| ())
             .map_ok(|chunk| stream::iter(chunk.data.into_iter().map(Ok)))
@@ -54,7 +54,7 @@ impl<
         Q: Query<T> + Clone + Send + 'static,
         E: Send + 'static,
         F: Send + Sync + 'static + Fn(IndexRef<T>) -> E,
-        S: Stream<Item = Tree<T>> + Send + 'static,
+        S: Stream<Item = Snapshot<T>> + Send + 'static,
     {
         let end = *range.end();
         let start_offset_ref = Arc::new(AtomicU64::new(*range.start()));
@@ -106,7 +106,7 @@ impl<
         Q: Query<T> + Clone + Send + 'static,
         E: Send + 'static,
         F: Send + Sync + 'static + Fn(IndexRef<T>) -> E,
-        S: Stream<Item = Tree<T>> + Send + 'static,
+        S: Stream<Item = Snapshot<T>> + Send + 'static,
     {
         let offset = Arc::new(AtomicU64::new(*range.start()));
         let forest = self.clone();
@@ -152,7 +152,7 @@ impl<
         Q: Query<T> + Clone + Send + 'static,
         E: Send + 'static,
         F: Send + Sync + 'static + Fn(IndexRef<T>) -> E,
-        S: Stream<Item = Tree<T>> + Send + 'static,
+        S: Stream<Item = Snapshot<T>> + Send + 'static,
     {
         let start = *range.start();
         let end_offset_ref = Arc::new(AtomicU64::new(*range.end()));

--- a/banyan/src/forest/write.rs
+++ b/banyan/src/forest/write.rs
@@ -60,7 +60,7 @@ where
             stream.config().max_leaf_count as usize,
         )?;
         let value_bytes = data.compressed().len() as u64;
-        let encrypted = data.into_encrypted(&stream.value_key().clone(), stream)?;
+        let encrypted = data.into_encrypted(&stream.value_key().clone(), &mut stream.offset)?;
         let keys = keys.into_iter().collect::<T::KeySeq>();
         let encrypted_len = encrypted.len();
         // store leaf
@@ -331,9 +331,9 @@ where
         let t0 = Instant::now();
         let cbor = serialize_compressed(
             &stream.index_key().clone(),
-            stream,
+            &mut stream.offset,
             &children,
-            stream.config().zstd_level,
+            stream.config.zstd_level,
         )?;
         let len = cbor.len() as u64;
         let result = Ok((self.writer.put(cbor)?, len));

--- a/banyan/src/forest/write.rs
+++ b/banyan/src/forest/write.rs
@@ -340,7 +340,7 @@ where
     ) -> Result<(T::Link, u64)> {
         let t0 = Instant::now();
         let level = stream.config().zstd_level;
-        let key = stream.index_key().clone();
+        let key = *stream.index_key();
         let cbor = serialize_compressed(&key, &mut stream.offset, &items, level)?;
         let len = cbor.len() as u64;
         let result = Ok((self.writer.put(cbor)?, len));

--- a/banyan/src/index.rs
+++ b/banyan/src/index.rs
@@ -38,11 +38,7 @@
 //! [CompactSeq]: trait.CompactSeq.html
 //! [Semigroup]: trait.Semigroup.html
 //! [SimpleCompactSeq]: struct.SimpleCompactSeq.html
-use crate::{
-    forest::TreeTypes,
-    tree::Offset,
-    zstd_dag_cbor_seq::ZstdDagCborSeq,
-};
+use crate::{forest::TreeTypes, tree::Offset, zstd_dag_cbor_seq::ZstdDagCborSeq};
 use anyhow::{anyhow, Result};
 use derive_more::From;
 use libipld::{

--- a/banyan/src/index.rs
+++ b/banyan/src/index.rs
@@ -38,7 +38,7 @@
 //! [CompactSeq]: trait.CompactSeq.html
 //! [Semigroup]: trait.Semigroup.html
 //! [SimpleCompactSeq]: struct.SimpleCompactSeq.html
-use crate::{forest::TreeTypes, tree::StreamBuilderState, zstd_dag_cbor_seq::ZstdDagCborSeq};
+use crate::{forest::TreeTypes, tree::{Offset, StreamBuilderState}, zstd_dag_cbor_seq::ZstdDagCborSeq};
 use anyhow::{anyhow, Result};
 use derive_more::From;
 use libipld::{
@@ -393,12 +393,12 @@ impl<T: TreeTypes> Display for NodeInfo<'_, T> {
 
 pub(crate) fn serialize_compressed<T: TreeTypes>(
     key: &chacha20::Key,
-    stream: &mut StreamBuilderState,
+    state: &mut Offset,
     items: &[Index<T>],
     level: i32,
 ) -> Result<Vec<u8>> {
     let zs = ZstdDagCborSeq::from_iter(items, level)?;
-    zs.into_encrypted(key, stream)
+    zs.into_encrypted(key, state)
 }
 
 pub(crate) fn deserialize_compressed<T: TreeTypes>(

--- a/banyan/src/index.rs
+++ b/banyan/src/index.rs
@@ -38,7 +38,7 @@
 //! [CompactSeq]: trait.CompactSeq.html
 //! [Semigroup]: trait.Semigroup.html
 //! [SimpleCompactSeq]: struct.SimpleCompactSeq.html
-use crate::{forest::TreeTypes, zstd_dag_cbor_seq::ZstdDagCborSeq, Offset};
+use crate::{forest::TreeTypes, zstd_dag_cbor_seq::ZstdDagCborSeq, StreamOffset};
 use anyhow::{anyhow, Result};
 use derive_more::From;
 use libipld::{
@@ -268,7 +268,7 @@ impl<T: TreeTypes> Index<T> {
 pub struct Branch<T: TreeTypes> {
     // index data for the children
     pub children: Arc<[Index<T>]>,
-    // offset of the branch
+    // stream offset at the start of this branch
     offset: u64,
 }
 
@@ -400,7 +400,7 @@ impl<T: TreeTypes> Display for NodeInfo<'_, T> {
 
 pub(crate) fn serialize_compressed<T: TreeTypes>(
     key: &chacha20::Key,
-    state: &mut Offset,
+    state: &mut StreamOffset,
     items: &[Index<T>],
     level: i32,
 ) -> Result<Vec<u8>> {

--- a/banyan/src/index.rs
+++ b/banyan/src/index.rs
@@ -268,21 +268,25 @@ impl<T: TreeTypes> Index<T> {
 pub struct Branch<T: TreeTypes> {
     // index data for the children
     pub children: Arc<[Index<T>]>,
+    // offset of the branch
+    offset: u64,
 }
 
 impl<T: TreeTypes> Clone for Branch<T> {
     fn clone(&self) -> Self {
         Self {
             children: self.children.clone(),
+            offset: self.offset,
         }
     }
 }
 
 impl<T: TreeTypes> Branch<T> {
-    pub fn new(children: Vec<Index<T>>) -> Self {
+    pub fn new(children: Vec<Index<T>>, offset: u64) -> Self {
         assert!(!children.is_empty());
         Self {
             children: children.into(),
+            offset,
         }
     }
     pub fn last_child(&self) -> &Index<T> {
@@ -306,11 +310,14 @@ impl<T: TreeTypes> Branch<T> {
 ///
 /// This is a wrapper around a cbor encoded and zstd compressed sequence of values
 #[derive(Debug)]
-pub struct Leaf(ZstdDagCborSeq);
+pub struct Leaf {
+    items: ZstdDagCborSeq,
+    offset: u64,
+}
 
 impl Leaf {
-    pub fn new(value: ZstdDagCborSeq) -> Self {
-        Self(value)
+    pub fn new(items: ZstdDagCborSeq, offset: u64) -> Self {
+        Self { items, offset }
     }
 
     pub fn child_at<T: DagCbor>(&self, offset: u64) -> Result<T> {
@@ -322,7 +329,7 @@ impl Leaf {
 
 impl AsRef<ZstdDagCborSeq> for Leaf {
     fn as_ref(&self) -> &ZstdDagCborSeq {
-        &self.0
+        &self.items
     }
 }
 

--- a/banyan/src/index.rs
+++ b/banyan/src/index.rs
@@ -393,7 +393,7 @@ impl<T: TreeTypes> Display for NodeInfo<'_, T> {
 
 pub(crate) fn serialize_compressed<T: TreeTypes>(
     key: &chacha20::Key,
-    offset: u64,
+    offset: &mut u64,
     items: &[Index<T>],
     level: i32,
 ) -> Result<Vec<u8>> {

--- a/banyan/src/index.rs
+++ b/banyan/src/index.rs
@@ -404,9 +404,10 @@ pub(crate) fn serialize_compressed<T: TreeTypes>(
 pub(crate) fn deserialize_compressed<T: TreeTypes>(
     key: &chacha20::Key,
     ipld: &[u8],
-) -> Result<Vec<Index<T>>> {
-    let seq = ZstdDagCborSeq::decrypt(ipld, key)?;
-    seq.items::<Index<T>>()
+) -> Result<(Vec<Index<T>>, u64)> {
+    let (seq, offset) = ZstdDagCborSeq::decrypt(ipld, key)?;
+    let seq = seq.items::<Index<T>>()?;
+    Ok((seq, offset))
 }
 
 /// Utility method to zip a number of indices with an offset that is increased by each index value

--- a/banyan/src/index.rs
+++ b/banyan/src/index.rs
@@ -40,7 +40,7 @@
 //! [SimpleCompactSeq]: struct.SimpleCompactSeq.html
 use crate::{
     forest::TreeTypes,
-    tree::{Offset, StreamBuilderState},
+    tree::Offset,
     zstd_dag_cbor_seq::ZstdDagCborSeq,
 };
 use anyhow::{anyhow, Result};

--- a/banyan/src/index.rs
+++ b/banyan/src/index.rs
@@ -393,12 +393,12 @@ impl<T: TreeTypes> Display for NodeInfo<'_, T> {
 
 pub(crate) fn serialize_compressed<T: TreeTypes>(
     key: &chacha20::Key,
-    offset: &mut StreamBuilderState,
+    stream: &mut StreamBuilderState,
     items: &[Index<T>],
     level: i32,
 ) -> Result<Vec<u8>> {
     let zs = ZstdDagCborSeq::from_iter(items, level)?;
-    zs.into_encrypted(key, offset)
+    zs.into_encrypted(key, stream)
 }
 
 pub(crate) fn deserialize_compressed<T: TreeTypes>(

--- a/banyan/src/index.rs
+++ b/banyan/src/index.rs
@@ -38,7 +38,7 @@
 //! [CompactSeq]: trait.CompactSeq.html
 //! [Semigroup]: trait.Semigroup.html
 //! [SimpleCompactSeq]: struct.SimpleCompactSeq.html
-use crate::{forest::TreeTypes, zstd_dag_cbor_seq::ZstdDagCborSeq};
+use crate::{forest::TreeTypes, tree::StreamBuilderState, zstd_dag_cbor_seq::ZstdDagCborSeq};
 use anyhow::{anyhow, Result};
 use derive_more::From;
 use libipld::{
@@ -393,7 +393,7 @@ impl<T: TreeTypes> Display for NodeInfo<'_, T> {
 
 pub(crate) fn serialize_compressed<T: TreeTypes>(
     key: &chacha20::Key,
-    offset: &mut u64,
+    offset: &mut StreamBuilderState,
     items: &[Index<T>],
     level: i32,
 ) -> Result<Vec<u8>> {

--- a/banyan/src/index.rs
+++ b/banyan/src/index.rs
@@ -38,7 +38,11 @@
 //! [CompactSeq]: trait.CompactSeq.html
 //! [Semigroup]: trait.Semigroup.html
 //! [SimpleCompactSeq]: struct.SimpleCompactSeq.html
-use crate::{forest::TreeTypes, tree::{Offset, StreamBuilderState}, zstd_dag_cbor_seq::ZstdDagCborSeq};
+use crate::{
+    forest::TreeTypes,
+    tree::{Offset, StreamBuilderState},
+    zstd_dag_cbor_seq::ZstdDagCborSeq,
+};
 use anyhow::{anyhow, Result};
 use derive_more::From;
 use libipld::{

--- a/banyan/src/index.rs
+++ b/banyan/src/index.rs
@@ -38,7 +38,7 @@
 //! [CompactSeq]: trait.CompactSeq.html
 //! [Semigroup]: trait.Semigroup.html
 //! [SimpleCompactSeq]: struct.SimpleCompactSeq.html
-use crate::{forest::TreeTypes, tree::Offset, zstd_dag_cbor_seq::ZstdDagCborSeq};
+use crate::{forest::TreeTypes, zstd_dag_cbor_seq::ZstdDagCborSeq, Offset};
 use anyhow::{anyhow, Result};
 use derive_more::From;
 use libipld::{

--- a/banyan/src/index.rs
+++ b/banyan/src/index.rs
@@ -393,12 +393,12 @@ impl<T: TreeTypes> Display for NodeInfo<'_, T> {
 
 pub(crate) fn serialize_compressed<T: TreeTypes>(
     key: &chacha20::Key,
-    nonce: &chacha20::XNonce,
+    offset: u64,
     items: &[Index<T>],
     level: i32,
 ) -> Result<Vec<u8>> {
     let zs = ZstdDagCborSeq::from_iter(items, level)?;
-    zs.into_encrypted(nonce, key)
+    zs.into_encrypted(key, offset)
 }
 
 pub(crate) fn deserialize_compressed<T: TreeTypes>(

--- a/banyan/src/lib.rs
+++ b/banyan/src/lib.rs
@@ -71,7 +71,7 @@ pub use chacha20;
 pub use zstd_dag_cbor_seq::ZstdDagCborSeq;
 
 pub use stream_builder::StreamBuilder;
-use stream_builder::{Offset, StreamBuilderState};
+use stream_builder::{StreamBuilderState, StreamOffset};
 
 #[cfg(test)]
 extern crate quickcheck;

--- a/banyan/src/lib.rs
+++ b/banyan/src/lib.rs
@@ -61,6 +61,7 @@ pub mod index;
 pub mod memstore;
 pub mod query;
 pub mod store;
+mod stream_builder;
 mod thread_local_zstd;
 pub mod tree;
 mod util;
@@ -68,6 +69,9 @@ mod zstd_dag_cbor_seq;
 
 pub use chacha20;
 pub use zstd_dag_cbor_seq::ZstdDagCborSeq;
+
+pub use stream_builder::StreamBuilder;
+use stream_builder::{Offset, StreamBuilderState};
 
 #[cfg(test)]
 extern crate quickcheck;

--- a/banyan/src/stream_builder.rs
+++ b/banyan/src/stream_builder.rs
@@ -1,0 +1,176 @@
+use core::fmt;
+use std::sync::Arc;
+
+use crate::{
+    forest::{Config, Secrets, TreeTypes},
+    index::Index,
+    tree::Tree,
+};
+
+/// A thing that hands out unique offsets. Parts of StreamBuilderState
+#[derive(Debug, Clone)]
+pub(crate) struct Offset {
+    value: u64,
+}
+
+impl Offset {
+    pub fn new(value: u64) -> Self {
+        Self { value }
+    }
+
+    pub fn reserve(&mut self, n: usize) -> u64 {
+        let result = self.value;
+        self.value = self
+            .value
+            .checked_add(n as u64)
+            .expect("ran out of offsets");
+        result
+    }
+
+    pub fn current(&self) -> u64 {
+        self.value
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct StreamBuilderState {
+    /// the secrets used for building the trees of the stream
+    secrets: Secrets,
+    /// config that determines the branch size etc.
+    config: Config,
+    /// current offset
+    pub(crate) offset: Offset,
+}
+
+impl StreamBuilderState {
+    pub fn new(offset: u64, secrets: Secrets, config: Config) -> Self {
+        Self {
+            offset: Offset::new(offset),
+            secrets,
+            config,
+        }
+    }
+
+    pub fn config(&self) -> &Config {
+        &self.config
+    }
+
+    pub fn secrets(&self) -> &Secrets {
+        &self.secrets
+    }
+
+    pub fn value_key(&self) -> &chacha20::Key {
+        self.secrets.value_key()
+    }
+
+    pub fn index_key(&self) -> &chacha20::Key {
+        self.secrets.index_key()
+    }
+}
+
+/// A builder for a stream of trees
+///
+/// Most of the logic except for handling the empty case is implemented in the forest
+pub struct StreamBuilder<T: TreeTypes> {
+    root: Option<Arc<Index<T>>>,
+    state: StreamBuilderState,
+}
+
+impl<T: TreeTypes> fmt::Debug for StreamBuilder<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.root {
+            Some(root) => f
+                .debug_struct("Tree")
+                .field("count", &self.count())
+                .field("key_bytes", &root.key_bytes())
+                .field("value_bytes", &root.value_bytes())
+                .field("link", &root.link())
+                .finish(),
+            None => f
+                .debug_struct("Tree")
+                .field("count", &self.count())
+                .finish(),
+        }
+    }
+}
+
+impl<T: TreeTypes> fmt::Display for StreamBuilder<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.root {
+            Some(root) => write!(f, "{:?}", root.link(),),
+            None => write!(f, "empty tree"),
+        }
+    }
+}
+
+impl<T: TreeTypes> Clone for StreamBuilder<T> {
+    fn clone(&self) -> Self {
+        Self {
+            root: self.root.clone(),
+            state: self.state.clone(),
+        }
+    }
+}
+
+impl<T: TreeTypes> StreamBuilder<T> {
+    pub(crate) fn state(&self) -> StreamBuilderState {
+        self.state.clone()
+    }
+
+    pub fn new(config: Config, secrets: Secrets) -> Self {
+        let state = StreamBuilderState::new(0, secrets, config);
+        Self::new_from_index(None, state)
+    }
+
+    pub(crate) fn new_from_index(root: Option<Index<T>>, state: StreamBuilderState) -> Self {
+        Self {
+            root: root.map(Arc::new),
+            state,
+        }
+    }
+
+    pub fn snapshot(&self) -> Tree<T> {
+        Tree::new(
+            self.root.clone(),
+            self.state.secrets().clone(),
+            self.state.offset.current(),
+        )
+    }
+
+    pub fn link(&self) -> Option<T::Link> {
+        self.root.as_ref().and_then(|r| *r.link())
+    }
+
+    pub fn as_index_ref(&self) -> Option<&Index<T>> {
+        self.root.as_ref().map(|arc| arc.as_ref())
+    }
+
+    pub fn level(&self) -> i32 {
+        self.root.as_ref().map(|x| x.level() as i32).unwrap_or(-1)
+    }
+
+    pub fn debug() -> Self {
+        let state = StreamBuilderState::new(0, Secrets::default(), Config::debug());
+        Self::new_from_index(None, state)
+    }
+
+    /// true for an empty tree
+    pub fn is_empty(&self) -> bool {
+        self.count() == 0
+    }
+
+    /// number of elements in the tree
+    pub fn count(&self) -> u64 {
+        self.root.as_ref().map(|x| x.count()).unwrap_or_default()
+    }
+
+    /// root of a non-empty tree
+    pub fn root(&self) -> Option<&T::Link> {
+        self.root.as_ref().and_then(|index| index.link().as_ref())
+    }
+
+    /// root of a non-empty tree
+    pub fn index(&self) -> Option<&Index<T>> {
+        self.root.as_ref().map(|x| x.as_ref())
+    }
+}

--- a/banyan/src/stream_builder.rs
+++ b/banyan/src/stream_builder.rs
@@ -9,11 +9,11 @@ use crate::{
 
 /// A thing that hands out unique offsets. Parts of StreamBuilderState
 #[derive(Debug, Clone)]
-pub(crate) struct Offset {
+pub(crate) struct StreamOffset {
     value: u64,
 }
 
-impl Offset {
+impl StreamOffset {
     pub fn new(value: u64) -> Self {
         Self { value }
     }
@@ -36,16 +36,19 @@ impl Offset {
 pub(crate) struct StreamBuilderState {
     /// the secrets used for building the trees of the stream
     secrets: Secrets,
-    /// config that determines the branch size etc.
+    /// tree config that determines the branch size etc.
     config: Config,
-    /// current offset
-    pub(crate) offset: Offset,
+    /// current stream offset
+    ///
+    /// this is the first free offset, or the total number of bytes ever written
+    /// on this stream.
+    pub(crate) offset: StreamOffset,
 }
 
 impl StreamBuilderState {
     pub fn new(offset: u64, secrets: Secrets, config: Config) -> Self {
         Self {
-            offset: Offset::new(offset),
+            offset: StreamOffset::new(offset),
             secrets,
             config,
         }

--- a/banyan/src/tree.rs
+++ b/banyan/src/tree.rs
@@ -636,7 +636,6 @@ impl<T: TreeTypes> Tree<T> {
         Self::new_with_offset(None, state)
     }
 
-    #[cfg(test)]
     pub fn debug() -> Self {
         let state = StreamBuilderState::new(0, CryptoConfig::default(), Config::debug());
         Self::new_with_offset(None, state)

--- a/banyan/src/tree.rs
+++ b/banyan/src/tree.rs
@@ -103,6 +103,10 @@ impl<T: TreeTypes> Tree<T> {
         let secrets = self.secrets.clone();
         self.root.map(|x| (x, secrets))
     }
+
+    pub(crate) fn as_index_ref(&self) -> Option<&Index<T>> {
+        self.root.as_ref().map(|arc| arc.as_ref())
+    }
 }
 
 impl<T: TreeTypes> fmt::Debug for StreamBuilder<T> {
@@ -277,11 +281,11 @@ impl<
     }
 
     /// leftmost branches of the tree as separate trees
-    pub fn left_roots(&self, tree: &StreamBuilder<T>) -> Result<Vec<StreamBuilder<T>>> {
+    pub fn left_roots(&self, tree: &Tree<T>) -> Result<Vec<Tree<T>>> {
         Ok(if let Some(index) = tree.as_index_ref() {
-            self.left_roots0(tree.state.secrets(), index)?
+            self.left_roots0(&tree.secrets, index)?
                 .into_iter()
-                .map(|x| StreamBuilder::new_from_index(Some(x), tree.state.clone()))
+                .map(|x| Tree::new(Some(Arc::new(x)), tree.secrets.clone(), u64::max_value()))
                 .collect()
         } else {
             Vec::new()

--- a/banyan/src/tree.rs
+++ b/banyan/src/tree.rs
@@ -59,20 +59,20 @@ impl<
         config: Config,
         link: T::Link,
     ) -> Result<StreamBuilder<T>> {
-        let (index, offset) = self.load_branch_from_link(
+        let (index, byte_range) = self.load_branch_from_link(
             &secrets,
             |items, level| config.branch_sealed(items, level),
             link,
         )?;
-        let state = StreamBuilderState::new(offset, secrets, config);
+        let state = StreamBuilderState::new(byte_range.end, secrets, config);
         Ok(StreamBuilder::new_from_index(Some(index), state))
     }
 
     pub fn load_tree(&self, secrets: Secrets, link: T::Link) -> Result<Tree<T>> {
         // we pass in a predicate that makes the nodes sealed, since we don't care
-        let (index, offset) = self.load_branch_from_link(&secrets, |_, _| true, link)?;
+        let (index, byte_range) = self.load_branch_from_link(&secrets, |_, _| true, link)?;
         // store the offset with the snapshot. Snapshots are immutable, so this won't change.
-        Ok(Tree::new(Some(Arc::new(index)), secrets, offset))
+        Ok(Tree::new(Some(Arc::new(index)), secrets, byte_range.end))
     }
 
     /// dumps the tree structure

--- a/banyan/src/tree.rs
+++ b/banyan/src/tree.rs
@@ -14,8 +14,7 @@ use libipld::cbor::DagCbor;
 use std::{collections::BTreeMap, fmt, fmt::Debug, iter, sync::Arc, usize};
 use tracing::*;
 
-type ReadConfig = Arc<Secrets>;
-
+/// A thing that hands out unique offsets. Parts of StreamBuilderState
 #[derive(Debug, Clone)]
 pub struct Offset {
     value: u64,
@@ -136,9 +135,9 @@ impl<
         R: ReadOnlyStore<T::Link> + Clone + Send + Sync + 'static,
     > Forest<T, V, R>
 {
-    pub fn load_tree(&self, stream: &StreamBuilderState, link: T::Link) -> Result<Tree<T>> {
-        let (index, offset) = self.load_branch_from_link(stream, link)?;
-        let state = StreamBuilderState::new(offset, stream.read_config, stream.config);
+    pub fn load_tree(&self, secrets: Secrets, config: Config, link: T::Link) -> Result<Tree<T>> {
+        let (index, offset) = self.load_branch_from_link(&secrets, &config, link)?;
+        let state = StreamBuilderState::new(offset, secrets, config);
         Ok(Tree::new_with_offset(Some(index), state))
     }
 
@@ -676,8 +675,8 @@ impl<T: TreeTypes> Tree<T> {
         self.root.as_ref().map(|x| x.level() as i32).unwrap_or(-1)
     }
 
-    pub fn empty(config: Config, crypto_config: Secrets) -> Self {
-        let state = StreamBuilderState::new(0, crypto_config, config);
+    pub fn empty(config: Config, secrets: Secrets) -> Self {
+        let state = StreamBuilderState::new(0, secrets, config);
         Self::new_with_offset(None, state)
     }
 

--- a/banyan/src/tree.rs
+++ b/banyan/src/tree.rs
@@ -541,11 +541,12 @@ impl<
         query: &'a Q,
     ) -> Result<()> {
         let index = tree.index().cloned();
-        Ok(if let Some(index) = index {
+        if let Some(index) = index {
             let mut level: i32 = i32::max_value();
             let index = self.retain0(0, query, &index, &mut level, tree.state_mut())?;
             tree.set_index(Some(index));
-        })
+        }
+        Ok(())
     }
 
     /// repair a tree by purging parts of the tree that can not be resolved.
@@ -558,14 +559,12 @@ impl<
     pub fn repair(&self, tree: &mut StreamBuilder<T>) -> Result<Vec<String>> {
         let mut report = Vec::new();
         let index = tree.index().cloned();
-        Ok(if let Some(index) = index {
+        if let Some(index) = index {
             let mut level: i32 = i32::max_value();
             let repaired = self.repair0(&index, &mut report, &mut level, tree.state_mut())?;
             tree.set_index(Some(repaired));
-            report
-        } else {
-            report
-        })
+        }
+        Ok(report)
     }
 }
 

--- a/banyan/src/zstd_dag_cbor_seq.rs
+++ b/banyan/src/zstd_dag_cbor_seq.rs
@@ -30,7 +30,10 @@ use std::{
     time::Instant,
 };
 
-use crate::{thread_local_zstd::decompress_and_transform, tree::{Offset, StreamBuilderState}};
+use crate::{
+    thread_local_zstd::decompress_and_transform,
+    tree::{Offset, StreamBuilderState},
+};
 use chacha20::{
     cipher::{NewCipher, StreamCipher, StreamCipherSeek},
     XChaCha20,
@@ -255,7 +258,11 @@ impl ZstdDagCborSeq {
     }
 
     /// convert into an encrypted blob, using the given key and nonce
-    pub fn into_encrypted(self, key: &chacha20::Key, state: &mut Offset) -> anyhow::Result<Vec<u8>> {
+    pub fn into_encrypted(
+        self,
+        key: &chacha20::Key,
+        state: &mut Offset,
+    ) -> anyhow::Result<Vec<u8>> {
         let Self { mut data, links } = self;
         // encrypt in place with the key and nonce
         let mut chacha20 = XChaCha20::new(key, &NONCE.into());

--- a/banyan/src/zstd_dag_cbor_seq.rs
+++ b/banyan/src/zstd_dag_cbor_seq.rs
@@ -30,7 +30,7 @@ use std::{
     time::Instant,
 };
 
-use crate::{thread_local_zstd::decompress_and_transform, Offset};
+use crate::{thread_local_zstd::decompress_and_transform, StreamOffset};
 use chacha20::{
     cipher::{NewCipher, StreamCipher, StreamCipherSeek},
     XChaCha20,
@@ -250,7 +250,7 @@ impl ZstdDagCborSeq {
 
     /// encrypt using the given key and nonce
     pub fn encrypt(&self, key: &chacha20::Key, offset: u64) -> anyhow::Result<Vec<u8>> {
-        let mut state = Offset::new(offset);
+        let mut state = StreamOffset::new(offset);
         self.clone().into_encrypted(key, &mut state)
     }
 
@@ -258,7 +258,7 @@ impl ZstdDagCborSeq {
     pub(crate) fn into_encrypted(
         self,
         key: &chacha20::Key,
-        state: &mut Offset,
+        state: &mut StreamOffset,
     ) -> anyhow::Result<Vec<u8>> {
         let Self { mut data, links } = self;
         // encrypt in place with the key and nonce

--- a/banyan/src/zstd_dag_cbor_seq.rs
+++ b/banyan/src/zstd_dag_cbor_seq.rs
@@ -30,7 +30,7 @@ use std::{
     time::Instant,
 };
 
-use crate::{thread_local_zstd::decompress_and_transform, tree::Offset};
+use crate::{thread_local_zstd::decompress_and_transform, Offset};
 use chacha20::{
     cipher::{NewCipher, StreamCipher, StreamCipherSeek},
     XChaCha20,
@@ -255,7 +255,7 @@ impl ZstdDagCborSeq {
     }
 
     /// convert into an encrypted blob, using the given key and nonce
-    pub fn into_encrypted(
+    pub(crate) fn into_encrypted(
         self,
         key: &chacha20::Key,
         state: &mut Offset,

--- a/banyan/src/zstd_dag_cbor_seq.rs
+++ b/banyan/src/zstd_dag_cbor_seq.rs
@@ -255,11 +255,11 @@ impl ZstdDagCborSeq {
     }
 
     /// convert into an encrypted blob, using the given key and nonce
-    pub fn into_encrypted(self, key: &chacha20::Key, offset: &mut StreamBuilderState) -> anyhow::Result<Vec<u8>> {
+    pub fn into_encrypted(self, key: &chacha20::Key, stream: &mut StreamBuilderState) -> anyhow::Result<Vec<u8>> {
         let Self { mut data, links } = self;
         // encrypt in place with the key and nonce
         let mut chacha20 = XChaCha20::new(key, &NONCE.into());
-        let offset = offset.allocate_offsets(data.len());
+        let offset = stream.allocate_offsets(data.len());
         chacha20.seek(offset);
         chacha20.apply_keystream(&mut data);
         // add the nonce

--- a/banyan/src/zstd_dag_cbor_seq.rs
+++ b/banyan/src/zstd_dag_cbor_seq.rs
@@ -30,7 +30,7 @@ use std::{
     time::Instant,
 };
 
-use crate::{thread_local_zstd::decompress_and_transform, tree::StreamBuilderState};
+use crate::{thread_local_zstd::decompress_and_transform, tree::{Offset, StreamBuilderState}};
 use chacha20::{
     cipher::{NewCipher, StreamCipher, StreamCipherSeek},
     XChaCha20,
@@ -250,16 +250,16 @@ impl ZstdDagCborSeq {
 
     /// encrypt using the given key and nonce
     pub fn encrypt(&self, key: &chacha20::Key, offset: u64) -> anyhow::Result<Vec<u8>> {
-        let mut state = StreamBuilderState::new(offset);
+        let mut state = Offset::new(offset);
         self.clone().into_encrypted(key, &mut state)
     }
 
     /// convert into an encrypted blob, using the given key and nonce
-    pub fn into_encrypted(self, key: &chacha20::Key, stream: &mut StreamBuilderState) -> anyhow::Result<Vec<u8>> {
+    pub fn into_encrypted(self, key: &chacha20::Key, state: &mut Offset) -> anyhow::Result<Vec<u8>> {
         let Self { mut data, links } = self;
         // encrypt in place with the key and nonce
         let mut chacha20 = XChaCha20::new(key, &NONCE.into());
-        let offset = stream.allocate_offsets(data.len());
+        let offset = state.reserve(data.len());
         chacha20.seek(offset);
         chacha20.apply_keystream(&mut data);
         // add the nonce

--- a/banyan/src/zstd_dag_cbor_seq.rs
+++ b/banyan/src/zstd_dag_cbor_seq.rs
@@ -348,7 +348,7 @@ mod tests {
 
     use super::*;
     use quickcheck::quickcheck;
-    use rand::{Rng, SeedableRng};
+    use rand::{Rng, RngCore, SeedableRng};
     use rand_chacha::ChaCha8Rng;
 
     #[test]
@@ -459,7 +459,7 @@ mod tests {
             usize::max_value(),
         )?;
         let mut rng = ChaCha8Rng::seed_from_u64(seed);
-        let offset = 1234u64;
+        let offset = rng.next_u64();
         let key: chacha20::Key = rng.gen::<[u8; 32]>().into();
         let encrypted = za.encrypt(&key, offset)?;
         let (za2, offset) = ZstdDagCborSeq::decrypt(&encrypted, &key)?;

--- a/banyan/src/zstd_dag_cbor_seq.rs
+++ b/banyan/src/zstd_dag_cbor_seq.rs
@@ -30,10 +30,7 @@ use std::{
     time::Instant,
 };
 
-use crate::{
-    thread_local_zstd::decompress_and_transform,
-    tree::Offset,
-};
+use crate::{thread_local_zstd::decompress_and_transform, tree::Offset};
 use chacha20::{
     cipher::{NewCipher, StreamCipher, StreamCipherSeek},
     XChaCha20,

--- a/banyan/src/zstd_dag_cbor_seq.rs
+++ b/banyan/src/zstd_dag_cbor_seq.rs
@@ -32,7 +32,7 @@ use std::{
 
 use crate::{
     thread_local_zstd::decompress_and_transform,
-    tree::{Offset, StreamBuilderState},
+    tree::Offset,
 };
 use chacha20::{
     cipher::{NewCipher, StreamCipher, StreamCipherSeek},

--- a/banyan/tests/build_check.rs
+++ b/banyan/tests/build_check.rs
@@ -1,4 +1,4 @@
-use banyan::{index::{BranchIndex, Index, LeafIndex}, memstore::MemStore, query::{AllQuery, EmptyQuery, OffsetRangeQuery}, tree::{StreamBuilderState, Tree}};
+use banyan::{forest::{Config, CryptoConfig}, index::{BranchIndex, Index, LeafIndex}, memstore::MemStore, query::{AllQuery, EmptyQuery, OffsetRangeQuery}, tree::{StreamBuilderState, Tree}};
 use common::{create_test_tree, txn, IterExt, Key, KeySeq, Sha256Digest, TT};
 use futures::prelude::*;
 use libipld::{cbor::DagCborCodec, codec::Codec, Cid};
@@ -202,7 +202,8 @@ fn build_get(xs: Vec<(Key, u64)>) -> anyhow::Result<bool> {
 fn build_pack(xss: Vec<Vec<(Key, u64)>>) -> anyhow::Result<bool> {
     let store = MemStore::new(usize::max_value(), Sha256Digest::digest);
     let forest = txn(store, 1000);
-    let mut tree = Tree::<TT>::empty();
+    let mut tree = Tree::<TT>::empty(Config::debug(), CryptoConfig::default());
+
     // flattened xss for reference
     let xs = xss.iter().cloned().flatten().collect::<Vec<_>>();
     // build complex unbalanced tree
@@ -232,7 +233,7 @@ fn build_pack(xss: Vec<Vec<(Key, u64)>>) -> anyhow::Result<bool> {
 fn do_retain(xss: Vec<Vec<(Key, u64)>>) -> anyhow::Result<bool> {
     let store = MemStore::new(usize::max_value(), Sha256Digest::digest);
     let forest = txn(store, 1000);
-    let mut tree = Tree::<TT>::empty();
+    let mut tree = Tree::<TT>::empty(Config::debug(), CryptoConfig::default());
     // flattened xss for reference
     let xs = xss.iter().cloned().flatten().collect::<Vec<_>>();
     // build complex unbalanced tree
@@ -256,7 +257,7 @@ fn retain(xss: Vec<Vec<(Key, u64)>>) -> anyhow::Result<bool> {
 fn iter_from_should_return_all_items(xs: Vec<(Key, u64)>) -> anyhow::Result<bool> {
     let store = MemStore::new(usize::max_value(), Sha256Digest::digest);
     let forest = txn(store, 1000);
-    let mut tree = Tree::<TT>::empty();
+    let mut tree = Tree::<TT>::empty(Config::debug(), CryptoConfig::default());
     tree = forest.extend(&tree, xs.clone().into_iter())?;
     forest.assert_invariants(&tree)?;
     let actual = forest
@@ -286,10 +287,10 @@ fn filter_test_simple() -> anyhow::Result<()> {
 async fn stream_test_simple() -> anyhow::Result<()> {
     let store = MemStore::new(usize::max_value(), Sha256Digest::digest);
     let forest = txn(store, 1000);
-    let stream = StreamBuilderState::new(0);
+    let stream = StreamBuilderState::new(0, CryptoConfig::default(), Config::debug());
     let mut trees = Vec::new();
     for n in 1..=10u64 {
-        let mut tree = Tree::<TT>::empty();
+        let mut tree = Tree::<TT>::empty(Config::debug(), CryptoConfig::default());
         tree = forest.extend(&tree, (0..n).map(|t| (Key(t), n)))?;
         forest.assert_invariants(&tree)?;
         trees.push(tree);
@@ -307,8 +308,8 @@ async fn stream_test_simple() -> anyhow::Result<()> {
 async fn stream_trees_chunked_reverse_should_complete() {
     let store = MemStore::new(usize::max_value(), Sha256Digest::digest);
     let forest = txn(store, 1000);
-    let stream = StreamBuilderState::new(0);
-    let mut tree = Tree::<TT>::empty();
+    let stream = StreamBuilderState::new(0, CryptoConfig::default(), Config::debug());
+    let mut tree = Tree::<TT>::empty(stream.config().clone(), stream.crypto_config().clone());
     tree = forest.extend_unpacked(&tree, vec![(Key(0), 0)]).unwrap();
     let trees = stream::once(async move { tree }).chain(stream::pending());
     let _ = forest
@@ -325,8 +326,8 @@ async fn stream_trees_chunked_reverse_should_complete() {
 async fn stream_trees_chunked_should_complete() {
     let store = MemStore::new(usize::max_value(), Sha256Digest::digest);
     let forest = txn(store, 1000);
-    let stream = StreamBuilderState::new(0);
-    let mut tree = Tree::<TT>::empty();
+    let stream = StreamBuilderState::new(0, CryptoConfig::default(), Config::debug());
+    let mut tree = Tree::<TT>::empty(stream.config().clone(), stream.crypto_config().clone());
     tree = forest.extend_unpacked(&tree, vec![(Key(0), 0)]).unwrap();
     let trees = stream::once(async move { tree }).chain(stream::pending());
     let _ = forest
@@ -359,7 +360,7 @@ fn deep_tree_traversal_no_stack_overflow() -> anyhow::Result<()> {
         .spawn(|| {
             let store = MemStore::new(usize::max_value(), Sha256Digest::digest);
             let forest = txn(store, 1000);
-            let mut tree = Tree::<TT>::empty();
+            let mut tree = Tree::<TT>::empty(Config::debug(), CryptoConfig::default());
             let elems = (0u64..100).map(|i| (i, Key(i), i)).collect::<Vec<_>>();
             for (_offset, k, v) in &elems {
                 tree = forest.extend_unpacked(&tree, vec![(*k, *v)]).unwrap();
@@ -550,7 +551,7 @@ fn build1() -> anyhow::Result<()> {
     let xs = (0..10).map(|i| (Key(i), i)).collect::<Vec<_>>();
     let store = MemStore::new(usize::max_value(), Sha256Digest::digest);
     let forest = txn(store, 1000);
-    let tree = forest.extend(&Tree::empty(), xs)?;
+    let tree = forest.extend(&Tree::empty(Config::debug(), CryptoConfig::default()), xs)?;
     forest.dump(&tree)?;
     // let foo = Tree::empty()
     Ok(())

--- a/banyan/tests/build_check.rs
+++ b/banyan/tests/build_check.rs
@@ -332,9 +332,9 @@ async fn stream_trees_chunked_should_honour_an_inclusive_upper_bound(
     }
     let store = MemStore::new(usize::max_value(), Sha256Digest::digest);
     let forest = txn(store, 1000);
-    let mut tree = Tree::<TT>::empty();
-    tree = forest.extend_unpacked(&tree, xs.clone().into_iter())?;
-    let trees = stream::once(async move { tree }).chain(stream::pending());
+    let mut tree = StreamBuilder::<TT>::debug();
+    forest.extend_unpacked(&mut tree, xs.clone().into_iter())?;
+    let trees = stream::once(async move { tree.snapshot() }).chain(stream::pending());
 
     let actual = forest
         .stream_trees_chunked(AllQuery, trees, 0u64..=(len - 1), &|_| ())
@@ -367,9 +367,9 @@ async fn stream_trees_chunked_reverse_should_honour_an_inclusive_upper_bound(
     }
     let store = MemStore::new(usize::max_value(), Sha256Digest::digest);
     let forest = txn(store, 1000);
-    let mut tree = Tree::<TT>::empty();
-    tree = forest.extend_unpacked(&tree, xs.clone().into_iter())?;
-    let trees = stream::once(async move { tree }).chain(stream::pending());
+    let mut tree = StreamBuilder::<TT>::debug();
+    forest.extend_unpacked(&mut tree, xs.clone().into_iter())?;
+    let trees = stream::once(async move { tree.snapshot() }).chain(stream::pending());
     let actual = forest
         .stream_trees_chunked_reverse(AllQuery, trees, 0u64..=(len - 1), &|_| ())
         .map_ok(move |chunk| stream::iter(chunk.data))

--- a/banyan/tests/build_check.rs
+++ b/banyan/tests/build_check.rs
@@ -1,4 +1,10 @@
-use banyan::{forest::{Config, CryptoConfig}, index::{BranchIndex, Index, LeafIndex}, memstore::MemStore, query::{AllQuery, EmptyQuery, OffsetRangeQuery}, tree::{StreamBuilderState, Tree}};
+use banyan::{
+    forest::{Config, Secrets},
+    index::{BranchIndex, Index, LeafIndex},
+    memstore::MemStore,
+    query::{AllQuery, EmptyQuery, OffsetRangeQuery},
+    tree::{StreamBuilderState, Tree},
+};
 use common::{create_test_tree, txn, IterExt, Key, KeySeq, Sha256Digest, TT};
 use futures::prelude::*;
 use libipld::{cbor::DagCborCodec, codec::Codec, Cid};
@@ -287,7 +293,7 @@ fn filter_test_simple() -> anyhow::Result<()> {
 async fn stream_test_simple() -> anyhow::Result<()> {
     let store = MemStore::new(usize::max_value(), Sha256Digest::digest);
     let forest = txn(store, 1000);
-    let stream = StreamBuilderState::new(0, CryptoConfig::default(), Config::debug());
+    let stream = StreamBuilderState::new(0, Secrets::default(), Config::debug());
     let mut trees = Vec::new();
     for n in 1..=10u64 {
         let mut tree = Tree::<TT>::debug();
@@ -296,9 +302,11 @@ async fn stream_test_simple() -> anyhow::Result<()> {
         trees.push(tree);
     }
     println!("{:?}", trees);
-    let res = forest
-        .read()
-        .stream_trees(stream, AllQuery, stream::iter(trees).boxed());
+    let res = forest.read().stream_trees(
+        stream.secrets().clone(),
+        AllQuery,
+        stream::iter(trees).boxed(),
+    );
     let res = res.collect::<Vec<_>>().await;
     println!("{:?}", res);
     Ok(())
@@ -308,12 +316,18 @@ async fn stream_test_simple() -> anyhow::Result<()> {
 async fn stream_trees_chunked_reverse_should_complete() {
     let store = MemStore::new(usize::max_value(), Sha256Digest::digest);
     let forest = txn(store, 1000);
-    let stream = StreamBuilderState::new(0, CryptoConfig::default(), Config::debug());
-    let mut tree = Tree::<TT>::empty(stream.config().clone(), stream.crypto_config().clone());
+    let stream = StreamBuilderState::new(0, Secrets::default(), Config::debug());
+    let mut tree = Tree::<TT>::empty(stream.config().clone(), stream.secrets().clone());
     tree = forest.extend_unpacked(&tree, vec![(Key(0), 0)]).unwrap();
     let trees = stream::once(async move { tree }).chain(stream::pending());
     let _ = forest
-        .stream_trees_chunked_reverse(stream, EmptyQuery, trees, 0u64..=0, &|_| ())
+        .stream_trees_chunked_reverse(
+            stream.secrets().clone(),
+            EmptyQuery,
+            trees,
+            0u64..=0,
+            &|_| (),
+        )
         .map_ok(move |chunk| stream::iter(chunk.data))
         .take_while(|x| future::ready(x.is_ok()))
         .filter_map(|x| future::ready(x.ok()))
@@ -326,12 +340,18 @@ async fn stream_trees_chunked_reverse_should_complete() {
 async fn stream_trees_chunked_should_complete() {
     let store = MemStore::new(usize::max_value(), Sha256Digest::digest);
     let forest = txn(store, 1000);
-    let stream = StreamBuilderState::new(0, CryptoConfig::default(), Config::debug());
-    let mut tree = Tree::<TT>::empty(stream.config().clone(), stream.crypto_config().clone());
+    let stream = StreamBuilderState::new(0, Secrets::default(), Config::debug());
+    let mut tree = Tree::<TT>::empty(stream.config().clone(), stream.secrets().clone());
     tree = forest.extend_unpacked(&tree, vec![(Key(0), 0)]).unwrap();
     let trees = stream::once(async move { tree }).chain(stream::pending());
     let _ = forest
-        .stream_trees_chunked(stream, EmptyQuery, trees, 0u64..=0, &|_| ())
+        .stream_trees_chunked(
+            stream.secrets().clone(),
+            EmptyQuery,
+            trees,
+            0u64..=0,
+            &|_| (),
+        )
         .map_ok(move |chunk| stream::iter(chunk.data))
         .take_while(|x| future::ready(x.is_ok()))
         .filter_map(|x| future::ready(x.ok()))

--- a/banyan/tests/build_check.rs
+++ b/banyan/tests/build_check.rs
@@ -293,7 +293,6 @@ fn filter_test_simple() -> anyhow::Result<()> {
 async fn stream_test_simple() -> anyhow::Result<()> {
     let store = MemStore::new(usize::max_value(), Sha256Digest::digest);
     let forest = txn(store, 1000);
-    let stream = StreamBuilderState::new(0, Secrets::default(), Config::debug());
     let mut trees = Vec::new();
     for n in 1..=10u64 {
         let mut tree = Tree::<TT>::debug();
@@ -302,11 +301,9 @@ async fn stream_test_simple() -> anyhow::Result<()> {
         trees.push(tree);
     }
     println!("{:?}", trees);
-    let res = forest.read().stream_trees(
-        stream.secrets().clone(),
-        AllQuery,
-        stream::iter(trees).boxed(),
-    );
+    let res = forest
+        .read()
+        .stream_trees(AllQuery, stream::iter(trees).boxed());
     let res = res.collect::<Vec<_>>().await;
     println!("{:?}", res);
     Ok(())
@@ -317,17 +314,11 @@ async fn stream_trees_chunked_reverse_should_complete() {
     let store = MemStore::new(usize::max_value(), Sha256Digest::digest);
     let forest = txn(store, 1000);
     let stream = StreamBuilderState::new(0, Secrets::default(), Config::debug());
-    let mut tree = Tree::<TT>::empty(stream.config().clone(), stream.secrets().clone());
+    let mut tree = Tree::<TT>::new(stream.config().clone(), stream.secrets().clone());
     tree = forest.extend_unpacked(&tree, vec![(Key(0), 0)]).unwrap();
     let trees = stream::once(async move { tree }).chain(stream::pending());
     let _ = forest
-        .stream_trees_chunked_reverse(
-            stream.secrets().clone(),
-            EmptyQuery,
-            trees,
-            0u64..=0,
-            &|_| (),
-        )
+        .stream_trees_chunked_reverse(EmptyQuery, trees, 0u64..=0, &|_| ())
         .map_ok(move |chunk| stream::iter(chunk.data))
         .take_while(|x| future::ready(x.is_ok()))
         .filter_map(|x| future::ready(x.ok()))
@@ -341,17 +332,11 @@ async fn stream_trees_chunked_should_complete() {
     let store = MemStore::new(usize::max_value(), Sha256Digest::digest);
     let forest = txn(store, 1000);
     let stream = StreamBuilderState::new(0, Secrets::default(), Config::debug());
-    let mut tree = Tree::<TT>::empty(stream.config().clone(), stream.secrets().clone());
+    let mut tree = Tree::<TT>::new(stream.config().clone(), stream.secrets().clone());
     tree = forest.extend_unpacked(&tree, vec![(Key(0), 0)]).unwrap();
     let trees = stream::once(async move { tree }).chain(stream::pending());
     let _ = forest
-        .stream_trees_chunked(
-            stream.secrets().clone(),
-            EmptyQuery,
-            trees,
-            0u64..=0,
-            &|_| (),
-        )
+        .stream_trees_chunked(EmptyQuery, trees, 0u64..=0, &|_| ())
         .map_ok(move |chunk| stream::iter(chunk.data))
         .take_while(|x| future::ready(x.is_ok()))
         .filter_map(|x| future::ready(x.ok()))

--- a/banyan/tests/build_check.rs
+++ b/banyan/tests/build_check.rs
@@ -298,7 +298,7 @@ async fn stream_test_simple() -> anyhow::Result<()> {
         let mut tree = Tree::<TT>::debug();
         tree = forest.extend(&tree, (0..n).map(|t| (Key(t), n)))?;
         forest.assert_invariants(&tree)?;
-        trees.push(tree);
+        trees.push(tree.snapshot());
     }
     println!("{:?}", trees);
     let res = forest
@@ -316,7 +316,7 @@ async fn stream_trees_chunked_reverse_should_complete() {
     let stream = StreamBuilderState::new(0, Secrets::default(), Config::debug());
     let mut tree = Tree::<TT>::new(stream.config().clone(), stream.secrets().clone());
     tree = forest.extend_unpacked(&tree, vec![(Key(0), 0)]).unwrap();
-    let trees = stream::once(async move { tree }).chain(stream::pending());
+    let trees = stream::once(async move { tree.snapshot() }).chain(stream::pending());
     let _ = forest
         .stream_trees_chunked_reverse(EmptyQuery, trees, 0u64..=0, &|_| ())
         .map_ok(move |chunk| stream::iter(chunk.data))
@@ -334,7 +334,7 @@ async fn stream_trees_chunked_should_complete() {
     let stream = StreamBuilderState::new(0, Secrets::default(), Config::debug());
     let mut tree = Tree::<TT>::new(stream.config().clone(), stream.secrets().clone());
     tree = forest.extend_unpacked(&tree, vec![(Key(0), 0)]).unwrap();
-    let trees = stream::once(async move { tree }).chain(stream::pending());
+    let trees = stream::once(async move { tree.snapshot() }).chain(stream::pending());
     let _ = forest
         .stream_trees_chunked(EmptyQuery, trees, 0u64..=0, &|_| ())
         .map_ok(move |chunk| stream::iter(chunk.data))

--- a/banyan/tests/build_check.rs
+++ b/banyan/tests/build_check.rs
@@ -202,7 +202,7 @@ fn build_get(xs: Vec<(Key, u64)>) -> anyhow::Result<bool> {
 fn build_pack(xss: Vec<Vec<(Key, u64)>>) -> anyhow::Result<bool> {
     let store = MemStore::new(usize::max_value(), Sha256Digest::digest);
     let forest = txn(store, 1000);
-    let mut tree = Tree::<TT>::empty(Config::debug(), CryptoConfig::default());
+    let mut tree = Tree::<TT>::debug();
 
     // flattened xss for reference
     let xs = xss.iter().cloned().flatten().collect::<Vec<_>>();
@@ -233,7 +233,7 @@ fn build_pack(xss: Vec<Vec<(Key, u64)>>) -> anyhow::Result<bool> {
 fn do_retain(xss: Vec<Vec<(Key, u64)>>) -> anyhow::Result<bool> {
     let store = MemStore::new(usize::max_value(), Sha256Digest::digest);
     let forest = txn(store, 1000);
-    let mut tree = Tree::<TT>::empty(Config::debug(), CryptoConfig::default());
+    let mut tree = Tree::<TT>::debug();
     // flattened xss for reference
     let xs = xss.iter().cloned().flatten().collect::<Vec<_>>();
     // build complex unbalanced tree
@@ -257,7 +257,7 @@ fn retain(xss: Vec<Vec<(Key, u64)>>) -> anyhow::Result<bool> {
 fn iter_from_should_return_all_items(xs: Vec<(Key, u64)>) -> anyhow::Result<bool> {
     let store = MemStore::new(usize::max_value(), Sha256Digest::digest);
     let forest = txn(store, 1000);
-    let mut tree = Tree::<TT>::empty(Config::debug(), CryptoConfig::default());
+    let mut tree = Tree::<TT>::debug();
     tree = forest.extend(&tree, xs.clone().into_iter())?;
     forest.assert_invariants(&tree)?;
     let actual = forest
@@ -290,7 +290,7 @@ async fn stream_test_simple() -> anyhow::Result<()> {
     let stream = StreamBuilderState::new(0, CryptoConfig::default(), Config::debug());
     let mut trees = Vec::new();
     for n in 1..=10u64 {
-        let mut tree = Tree::<TT>::empty(Config::debug(), CryptoConfig::default());
+        let mut tree = Tree::<TT>::debug();
         tree = forest.extend(&tree, (0..n).map(|t| (Key(t), n)))?;
         forest.assert_invariants(&tree)?;
         trees.push(tree);
@@ -360,7 +360,7 @@ fn deep_tree_traversal_no_stack_overflow() -> anyhow::Result<()> {
         .spawn(|| {
             let store = MemStore::new(usize::max_value(), Sha256Digest::digest);
             let forest = txn(store, 1000);
-            let mut tree = Tree::<TT>::empty(Config::debug(), CryptoConfig::default());
+            let mut tree = Tree::<TT>::debug();
             let elems = (0u64..100).map(|i| (i, Key(i), i)).collect::<Vec<_>>();
             for (_offset, k, v) in &elems {
                 tree = forest.extend_unpacked(&tree, vec![(*k, *v)]).unwrap();
@@ -551,7 +551,7 @@ fn build1() -> anyhow::Result<()> {
     let xs = (0..10).map(|i| (Key(i), i)).collect::<Vec<_>>();
     let store = MemStore::new(usize::max_value(), Sha256Digest::digest);
     let forest = txn(store, 1000);
-    let tree = forest.extend(&Tree::empty(Config::debug(), CryptoConfig::default()), xs)?;
+    let tree = forest.extend(&Tree::debug(), xs)?;
     forest.dump(&tree)?;
     // let foo = Tree::empty()
     Ok(())

--- a/banyan/tests/common/mod.rs
+++ b/banyan/tests/common/mod.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::upper_case_acronyms)]
 //! helper methods for the tests
 use banyan::{
-    forest::{BranchCache, Config, Secrets, Forest, Transaction, TreeTypes},
+    forest::{BranchCache, Forest, Transaction, TreeTypes},
     index::{CompactSeq, Summarizable},
     memstore::MemStore,
     tree::Tree,

--- a/banyan/tests/common/mod.rs
+++ b/banyan/tests/common/mod.rs
@@ -101,7 +101,7 @@ where
 {
     let store = MemStore::new(usize::max_value(), Sha256Digest::digest);
     let forest = txn(store, 1000);
-    let mut tree = Tree::<TT>::empty();
+    let mut tree = Tree::<TT>::empty(Config::debug(), CryptoConfig::default());
     tree = forest.extend(&tree, xs)?;
     forest.assert_invariants(&tree)?;
     Ok((tree, forest))

--- a/banyan/tests/common/mod.rs
+++ b/banyan/tests/common/mod.rs
@@ -4,7 +4,8 @@ use banyan::{
     forest::{BranchCache, Forest, Transaction, TreeTypes},
     index::{CompactSeq, Summarizable},
     memstore::MemStore,
-    tree::{StreamBuilder, Tree},
+    tree::Tree,
+    StreamBuilder,
 };
 use futures::Future;
 use libipld::{

--- a/banyan/tests/common/mod.rs
+++ b/banyan/tests/common/mod.rs
@@ -88,8 +88,6 @@ pub fn txn(store: MemStore<Sha256Digest>, cache_cap: usize) -> Txn {
         Forest::new(
             store.clone(),
             branch_cache,
-            CryptoConfig::default(),
-            Config::debug(),
         ),
         store,
     )

--- a/banyan/tests/common/mod.rs
+++ b/banyan/tests/common/mod.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::upper_case_acronyms)]
 //! helper methods for the tests
 use banyan::{
-    forest::{BranchCache, Config, CryptoConfig, Forest, Transaction, TreeTypes},
+    forest::{BranchCache, Config, Secrets, Forest, Transaction, TreeTypes},
     index::{CompactSeq, Summarizable},
     memstore::MemStore,
     tree::Tree,
@@ -84,13 +84,7 @@ impl Arbitrary for Key {
 #[allow(dead_code)]
 pub fn txn(store: MemStore<Sha256Digest>, cache_cap: usize) -> Txn {
     let branch_cache = BranchCache::new(cache_cap);
-    Txn::new(
-        Forest::new(
-            store.clone(),
-            branch_cache,
-        ),
-        store,
-    )
+    Txn::new(Forest::new(store.clone(), branch_cache), store)
 }
 
 #[allow(dead_code)]

--- a/banyan/tests/common/mod.rs
+++ b/banyan/tests/common/mod.rs
@@ -101,7 +101,7 @@ where
 {
     let store = MemStore::new(usize::max_value(), Sha256Digest::digest);
     let forest = txn(store, 1000);
-    let mut tree = Tree::<TT>::empty(Config::debug(), CryptoConfig::default());
+    let mut tree = Tree::<TT>::debug();
     tree = forest.extend(&tree, xs)?;
     forest.assert_invariants(&tree)?;
     Ok((tree, forest))

--- a/banyan/tests/common/mod.rs
+++ b/banyan/tests/common/mod.rs
@@ -4,7 +4,7 @@ use banyan::{
     forest::{BranchCache, Forest, Transaction, TreeTypes},
     index::{CompactSeq, Summarizable},
     memstore::MemStore,
-    tree::Tree,
+    tree::{StreamBuilder, Tree},
 };
 use futures::Future;
 use libipld::{
@@ -95,10 +95,10 @@ where
 {
     let store = MemStore::new(usize::max_value(), Sha256Digest::digest);
     let forest = txn(store, 1000);
-    let mut tree = Tree::<TT>::debug();
+    let mut tree = StreamBuilder::<TT>::debug();
     tree = forest.extend(&tree, xs)?;
     forest.assert_invariants(&tree)?;
-    Ok((tree, forest))
+    Ok((tree.snapshot(), forest))
 }
 
 #[allow(dead_code)]

--- a/banyan/tests/link_scraping.rs
+++ b/banyan/tests/link_scraping.rs
@@ -1,7 +1,6 @@
 #![allow(clippy::upper_case_acronyms)]
 use banyan::{
-    forest::{BranchCache, Secrets, Forest},
-    forest::{Config, Transaction, TreeTypes},
+    forest::{BranchCache, Forest, Transaction, TreeTypes}, 
     index::{UnitSeq, VecSeq},
     memstore::MemStore,
     tree::Tree,

--- a/banyan/tests/link_scraping.rs
+++ b/banyan/tests/link_scraping.rs
@@ -3,7 +3,8 @@ use banyan::{
     forest::{BranchCache, Forest, Transaction, TreeTypes},
     index::{UnitSeq, VecSeq},
     memstore::MemStore,
-    tree::{StreamBuilder, Tree},
+    tree::Tree,
+    StreamBuilder,
 };
 use common::Sha256Digest;
 use fnv::FnvHashSet;

--- a/banyan/tests/link_scraping.rs
+++ b/banyan/tests/link_scraping.rs
@@ -81,7 +81,7 @@ where
 {
     let store = MemStore::new(usize::max_value(), Sha256Digest::digest);
     let forest = txn(store);
-    let mut tree = Tree::<TT>::empty();
+    let mut tree = Tree::<TT>::empty(Config::debug(), CryptoConfig::default());
     tree = forest.extend(&tree, xs)?;
     forest.assert_invariants(&tree)?;
     Ok((tree, forest))

--- a/banyan/tests/link_scraping.rs
+++ b/banyan/tests/link_scraping.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::upper_case_acronyms)]
 use banyan::{
-    forest::{BranchCache, Forest, Transaction, TreeTypes}, 
+    forest::{BranchCache, Forest, Transaction, TreeTypes},
     index::{UnitSeq, VecSeq},
     memstore::MemStore,
     tree::Tree,

--- a/banyan/tests/link_scraping.rs
+++ b/banyan/tests/link_scraping.rs
@@ -69,8 +69,6 @@ fn txn(store: MemStore<Sha256Digest>) -> Txn {
         Forest::new(
             store.clone(),
             branch_cache,
-            CryptoConfig::default(),
-            Config::debug(),
         ),
         store,
     )

--- a/banyan/tests/link_scraping.rs
+++ b/banyan/tests/link_scraping.rs
@@ -81,7 +81,7 @@ where
 {
     let store = MemStore::new(usize::max_value(), Sha256Digest::digest);
     let forest = txn(store);
-    let mut tree = Tree::<TT>::empty(Config::debug(), CryptoConfig::default());
+    let mut tree = Tree::<TT>::debug();
     tree = forest.extend(&tree, xs)?;
     forest.assert_invariants(&tree)?;
     Ok((tree, forest))

--- a/banyan/tests/link_scraping.rs
+++ b/banyan/tests/link_scraping.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::upper_case_acronyms)]
 use banyan::{
-    forest::{BranchCache, CryptoConfig, Forest},
+    forest::{BranchCache, Secrets, Forest},
     forest::{Config, Transaction, TreeTypes},
     index::{UnitSeq, VecSeq},
     memstore::MemStore,
@@ -65,13 +65,7 @@ impl TreeTypes for TT {
 
 fn txn(store: MemStore<Sha256Digest>) -> Txn {
     let branch_cache = BranchCache::default();
-    Txn::new(
-        Forest::new(
-            store.clone(),
-            branch_cache,
-        ),
-        store,
-    )
+    Txn::new(Forest::new(store.clone(), branch_cache), store)
 }
 
 fn create_test_tree<I>(xs: I) -> anyhow::Result<(Tree<TT>, Txn)>

--- a/banyan/tests/link_scraping.rs
+++ b/banyan/tests/link_scraping.rs
@@ -3,7 +3,7 @@ use banyan::{
     forest::{BranchCache, Forest, Transaction, TreeTypes},
     index::{UnitSeq, VecSeq},
     memstore::MemStore,
-    tree::Tree,
+    tree::{StreamBuilder, Tree},
 };
 use common::Sha256Digest;
 use fnv::FnvHashSet;
@@ -74,10 +74,10 @@ where
 {
     let store = MemStore::new(usize::max_value(), Sha256Digest::digest);
     let forest = txn(store);
-    let mut tree = Tree::<TT>::debug();
+    let mut tree = StreamBuilder::<TT>::debug();
     tree = forest.extend(&tree, xs)?;
     forest.assert_invariants(&tree)?;
-    Ok((tree, forest))
+    Ok((tree.snapshot(), forest))
 }
 
 fn links_get_properly_scraped(xs: Vec<(Key, Payload)>) -> anyhow::Result<bool> {


### PR DESCRIPTION
Motivation: quoted from slack

So, the change from nonces to offsets: on the one side this is pretty straightforward, on the other side it fundamentally changes what a banyan tree is.

For now, with the random nonce, a single tree can have multiple "futures". You can have a tree and append a few events, and then have the same tree and append a few other events, and everything will be safe.

But with the offset, this is no longer the case, since you MUST NOT reuse offsets. So you need to make sure that a tree has only one future.

Turns out that the latter is more close to how we use it, so it is not a bad change.

Overview:

given the problem statement above, we try to enforce linear use of the offset by the following means:

- there is a type `Tree` that is merely a snapshot and can not be extended. This is used almost everywhere where reading is done, e.g. in the stream_trees fns. The tree carries the root index as well as the crypto config, which have been renamed to `Secrets`.

- for building, there is a type `StreamBuilder` which internally holds a root index and a StreamBuilderState, consisting of the Offset, the tree config, and the tree `Secrets`. At any time, a snapshot can be taken from a `StreamBuilder` that gives the current tree.

`Forest` loses the config and secrets. It is now just a way to read blocks and a common cache.

This solves a lot of longstanding problems.

E.g. it was always a major annoyance that you needed a tree config to do read ops on a tree, when this really is not needed unless you want to append.

A stream of trees now can change its secret from one tree to the next, and everything will still work. Whereas before it was assumed that the secret would remain the same. We might need this for key rotation.

In general, methods don't get stuff they don't need.

---

This is a step that should be relatively harmless to track in Cosmos. There will be another step, which will change things to use the rust type system to even more strictly enforce linear use of the tree offset. But that might be more difficult to integrate into Cosmos, so I don't want to do it in one PR. We will see.