### PR TITLE
Make the tree transform methods take a &mut StreamBuilder

### DIFF
--- a/banyan/src/stream_builder.rs
+++ b/banyan/src/stream_builder.rs
@@ -32,7 +32,7 @@ impl Offset {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(crate) struct StreamBuilderState {
     /// the secrets used for building the trees of the stream
     secrets: Secrets,
@@ -103,18 +103,13 @@ impl<T: TreeTypes> fmt::Display for StreamBuilder<T> {
     }
 }
 
-impl<T: TreeTypes> Clone for StreamBuilder<T> {
-    fn clone(&self) -> Self {
-        Self {
-            root: self.root.clone(),
-            state: self.state.clone(),
-        }
-    }
-}
-
 impl<T: TreeTypes> StreamBuilder<T> {
-    pub(crate) fn state(&self) -> StreamBuilderState {
-        self.state.clone()
+    pub(crate) fn state(&self) -> &StreamBuilderState {
+        &self.state
+    }
+
+    pub(crate) fn state_mut(&mut self) -> &mut StreamBuilderState {
+        &mut self.state
     }
 
     pub fn new(config: Config, secrets: Secrets) -> Self {
@@ -172,5 +167,9 @@ impl<T: TreeTypes> StreamBuilder<T> {
     /// root of a non-empty tree
     pub fn index(&self) -> Option<&Index<T>> {
         self.root.as_ref().map(|x| x.as_ref())
+    }
+
+    pub(crate) fn set_index(&mut self, index: Option<Index<T>>) {
+        self.root = index.map(Arc::new)
     }
 }

--- a/banyan/tests/common/mod.rs
+++ b/banyan/tests/common/mod.rs
@@ -97,7 +97,7 @@ where
     let store = MemStore::new(usize::max_value(), Sha256Digest::digest);
     let forest = txn(store, 1000);
     let mut tree = StreamBuilder::<TT>::debug();
-    tree = forest.extend(&tree, xs)?;
+    forest.extend(&mut tree, xs)?;
     forest.assert_invariants(&tree)?;
     Ok((tree.snapshot(), forest))
 }

--- a/banyan/tests/link_scraping.rs
+++ b/banyan/tests/link_scraping.rs
@@ -76,7 +76,7 @@ where
     let store = MemStore::new(usize::max_value(), Sha256Digest::digest);
     let forest = txn(store);
     let mut tree = StreamBuilder::<TT>::debug();
-    tree = forest.extend(&tree, xs)?;
+    forest.extend(&mut tree, xs)?;
     forest.assert_invariants(&tree)?;
     Ok((tree.snapshot(), forest))
 }


### PR DESCRIPTION
...and do not allow clone for StreamBuilder and StreamBuilderState

that way it is more difficult to shoot yourself in the foot...

Followup of #76