### PR TITLE
`stream_trees_chunked`: Fix off by one

### DIFF
--- a/banyan/src/forest/stream.rs
+++ b/banyan/src/forest/stream.rs
@@ -80,7 +80,8 @@ impl<
             });
         // make sure we terminate when `end` is reached
         take_until_condition(result, move |chunk| match chunk {
-            Ok(chunk) => chunk.range.end >= end,
+            // end is inclusive, whereas `chunk.range.end` is exclusive
+            Ok(chunk) => chunk.range.end > end,
             Err(_) => true,
         })
     }


### PR DESCRIPTION
The termination criterion introduced in #74 compares a `RangeInclusive`
with a `Range`. In case the chunk bound is exactly one item less than
the supplied query range, the last event is not emitted.