### PR TITLE
Move arc inside

### DIFF
--- a/banyan-utils/src/bin/cli.rs
+++ b/banyan-utils/src/bin/cli.rs
@@ -424,10 +424,8 @@ async fn main() -> Result<()> {
             )];
             let query = DnfQuery(tags).boxed();
             let values: Vec<_> = forest
-                .stream_filtered(&tree, query)
-                .map_ok(|(_, k, v)| (k, v))
-                .collect::<Vec<_>>()
-                .await;
+                .iter_filtered(&tree, query)
+                .collect::<Vec<_>>();
             println!("{}", values.len());
             let t1 = std::time::Instant::now();
             let tfilter_common = t1 - t0;
@@ -439,10 +437,8 @@ async fn main() -> Result<()> {
             )];
             let query = DnfQuery(tags).boxed();
             let values: Vec<_> = forest
-                .stream_filtered(&tree, query)
-                .map_ok(|(_, k, v)| (k, v))
-                .collect::<Vec<_>>()
-                .await;
+                .iter_filtered(&tree, query)
+                .collect::<Vec<_>>();
             println!("{}", values.len());
             let t1 = std::time::Instant::now();
             let tfilter_rare = t1 - t0;

--- a/banyan/src/forest/write.rs
+++ b/banyan/src/forest/write.rs
@@ -367,7 +367,7 @@ where
         }
         match index {
             Index::Branch(index) => {
-                let mut index = index.clone();
+                let mut index = index.as_ref().clone();
                 // only do the check unless we are already purged
                 let mut matching = vec![true; index.summaries.len()];
                 query.intersecting(offset, &index, &mut matching);
@@ -402,7 +402,7 @@ where
             }
             Index::Leaf(index) => {
                 // only do the check unless we are already purged
-                let mut index = index.clone();
+                let mut index = index.as_ref().clone();
                 if index.sealed && index.link.is_some() && *level >= 0 {
                     let mut matching = vec![true; index.keys.len()];
                     query.containing(offset, &index, &mut matching);
@@ -429,7 +429,7 @@ where
             Index::Branch(index) => {
                 // important not to hit the cache here!
                 let branch = self.load_branch(stream.secrets(), index);
-                let mut index = index.clone();
+                let mut index = index.as_ref().clone();
                 match branch {
                     Ok(Some(node)) => {
                         let mut children = node.children.to_vec();
@@ -464,7 +464,7 @@ where
                 Ok(index.into())
             }
             Index::Leaf(index) => {
-                let mut index = index.clone();
+                let mut index = index.as_ref().clone();
                 // important not to hit the cache here!
                 if let Err(cause) = self.load_leaf(stream.secrets(), &index) {
                     let link_txt = index.link.map(|x| x.to_string()).unwrap_or_default();

--- a/banyan/src/index.rs
+++ b/banyan/src/index.rs
@@ -184,13 +184,25 @@ impl<T: TreeTypes> BranchIndex<T> {
 }
 
 /// enum for a leaf or branch index
-#[derive(Debug, From, DagCbor)]
+#[derive(Debug, DagCbor)]
 #[ipld(repr = "kinded")]
 pub enum Index<T: TreeTypes> {
     #[ipld(repr = "value")]
-    Leaf(LeafIndex<T>),
+    Leaf(Arc<LeafIndex<T>>),
     #[ipld(repr = "value")]
-    Branch(BranchIndex<T>),
+    Branch(Arc<BranchIndex<T>>),
+}
+
+impl<T: TreeTypes> From<LeafIndex<T>> for Index<T> {
+    fn from(value: LeafIndex<T>) -> Self {
+        Index::Leaf(Arc::new(value))
+    }
+}
+
+impl<T: TreeTypes> From<BranchIndex<T>> for Index<T> {
+    fn from(value: BranchIndex<T>) -> Self {
+        Index::Branch(Arc::new(value))
+    }
 }
 
 /// enum for a leaf or branch index
@@ -327,18 +339,18 @@ impl AsRef<ZstdDagCborSeq> for Leaf {
 
 #[derive(Debug)]
 /// enum that combines index and corresponding data
-pub enum NodeInfo<'a, T: TreeTypes> {
+pub enum NodeInfo<T: TreeTypes> {
     // Branch with index and data
-    Branch(&'a BranchIndex<T>, Branch<T>),
+    Branch(Arc<BranchIndex<T>>, Branch<T>),
     /// Leaf with index and data
-    Leaf(&'a LeafIndex<T>, Leaf),
+    Leaf(Arc<LeafIndex<T>>, Leaf),
     /// Purged branch, with just the index
-    PurgedBranch(&'a BranchIndex<T>),
+    PurgedBranch(Arc<BranchIndex<T>>),
     /// Purged leaf, with just the index
-    PurgedLeaf(&'a LeafIndex<T>),
+    PurgedLeaf(Arc<LeafIndex<T>>),
 }
 
-impl<T: TreeTypes> Display for NodeInfo<'_, T> {
+impl<T: TreeTypes> Display for NodeInfo<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             NodeInfo::Leaf(index, _) => {

--- a/banyan/src/stream_builder.rs
+++ b/banyan/src/stream_builder.rs
@@ -1,8 +1,5 @@
 use core::fmt;
-use std::{
-    ops::{Deref, DerefMut},
-    sync::Arc,
-};
+use std::ops::{Deref, DerefMut};
 
 use crate::{
     forest::{Config, Secrets, TreeTypes},
@@ -81,7 +78,7 @@ impl StreamBuilderState {
 ///
 /// Most of the logic except for handling the empty case is implemented in the forest
 pub struct StreamBuilder<T: TreeTypes> {
-    root: Option<Arc<Index<T>>>,
+    root: Option<Index<T>>,
     state: StreamBuilderState,
 }
 
@@ -149,7 +146,7 @@ impl<T: TreeTypes> StreamBuilder<T> {
     }
 
     pub fn as_index_ref(&self) -> Option<&Index<T>> {
-        self.root.as_ref().map(|arc| arc.as_ref())
+        self.root.as_ref()
     }
 
     pub fn level(&self) -> i32 {
@@ -173,7 +170,7 @@ impl<T: TreeTypes> StreamBuilder<T> {
 
     /// root of a non-empty tree
     pub fn index(&self) -> Option<&Index<T>> {
-        self.root.as_ref().map(|x| x.as_ref())
+        self.root.as_ref()
     }
 
     /// Modify a StreamBuilder and roll back the changes if the operation was not successful
@@ -192,14 +189,11 @@ impl<T: TreeTypes> StreamBuilder<T> {
     }
 
     pub(crate) fn new_from_index(root: Option<Index<T>>, state: StreamBuilderState) -> Self {
-        Self {
-            root: root.map(Arc::new),
-            state,
-        }
+        Self { root, state }
     }
 
     pub(crate) fn set_index(&mut self, index: Option<Index<T>>) {
-        self.root = index.map(Arc::new)
+        self.root = index
     }
 }
 

--- a/banyan/src/tree.rs
+++ b/banyan/src/tree.rs
@@ -353,7 +353,6 @@ impl<
         match &tree.0 {
             Some((index, secrets, _)) => self
                 .iter_filtered0(secrets.clone(), query, index.clone())
-                .boxed()
                 .left_iter(),
             None => iter::empty().right_iter(),
         }
@@ -367,7 +366,6 @@ impl<
         match &tree.0 {
             Some((index, secrets, _)) => self
                 .iter_filtered_reverse0(secrets.clone(), query, index.clone())
-                .boxed()
                 .left_iter(),
             None => iter::empty().right_iter(),
         }

--- a/banyan/tests/build_check.rs
+++ b/banyan/tests/build_check.rs
@@ -148,7 +148,7 @@ fn iter_index(xs: Vec<(Key, u64)>) -> anyhow::Result<bool> {
 
     // should visit all indices
     let cnt = actual.iter().fold(0, |acc, idx| {
-        if let Index::Leaf(l) = idx.as_ref() {
+        if let Index::Leaf(l) = idx {
             acc + l.keys().count() as u64
         } else {
             acc
@@ -514,7 +514,7 @@ fn deep_tree_traversal_no_stack_overflow() -> anyhow::Result<()> {
 
 #[test]
 fn leaf_index_wire_format() -> anyhow::Result<()> {
-    let index: Index<TT> = Index::Leaf(LeafIndex {
+    let index: Index<TT> = LeafIndex {
         sealed: true,
         value_bytes: 1234,
         keys: KeySeq(vec![Key(1), Key(2)]),
@@ -522,7 +522,8 @@ fn leaf_index_wire_format() -> anyhow::Result<()> {
             Cid::from_str("bafyreihtx752fmf3zafbys5dtr4jxohb53yi3qtzfzf6wd5274jwtn5agu")?
                 .try_into()?,
         ),
-    });
+    }
+    .into();
     let serialized = DagCborCodec.encode(&index)?;
     let expected = from_cbor_me(
         r#"
@@ -555,7 +556,7 @@ A4                                      # map(4)
 
 #[test]
 fn branch_index_wire_format() -> anyhow::Result<()> {
-    let index: Index<TT> = Index::Branch(BranchIndex {
+    let index: Index<TT> = BranchIndex {
         count: 36784,
         level: 3,
         sealed: true,
@@ -566,7 +567,8 @@ fn branch_index_wire_format() -> anyhow::Result<()> {
             Cid::from_str("bafyreihtx752fmf3zafbys5dtr4jxohb53yi3qtzfzf6wd5274jwtn5agu")?
                 .try_into()?,
         ),
-    });
+    }
+    .into();
     let serialized = DagCborCodec.encode(&index)?;
     let expected = from_cbor_me(
         r#"


### PR DESCRIPTION
Instead of Arc<Index<T>>, use Index<T>, where both branches of the enum have an arc.