### PR TITLE
Fix perf regression in traversal

### DIFF
--- a/banyan-utils/examples/filter_tiny.rs
+++ b/banyan-utils/examples/filter_tiny.rs
@@ -81,8 +81,8 @@ fn main() -> anyhow::Result<()> {
     );
     let config = Config {
         target_leaf_size: 1 << 14,
-        max_leaf_count: 1 << 14,
-        max_branch_count: 32,
+        max_leaf_count: 1 << 12,
+        max_branch_count: 8,
         zstd_level: 10,
         max_uncompressed_leaf_size: 16 * 1024 * 1024,
     };
@@ -93,7 +93,7 @@ fn main() -> anyhow::Result<()> {
     println!("{:?}", tree);
 
     for _i in 0..1000 {
-        let (xs4, _, r_iter_tiny) = test_ops_count("", &txn, &tree, OffsetRangeQuery::from(0..10));
+        let (xs4, _, _) = test_ops_count("", &txn, &tree, OffsetRangeQuery::from(0..10));
         assert!(xs4.len() as u64 == 10);
         // assert_eq!(r_iter_tiny, 4);
     }

--- a/banyan-utils/examples/filter_tiny.rs
+++ b/banyan-utils/examples/filter_tiny.rs
@@ -1,3 +1,5 @@
+//! Example for filtering a small number of events out of a rather large banyan tree
+//! Finding the needle in the haystack. Mostly for using cargo flamegraph.
 use std::{
     sync::{
         atomic::{AtomicU64, Ordering},

--- a/banyan-utils/examples/filter_tiny.rs
+++ b/banyan-utils/examples/filter_tiny.rs
@@ -68,7 +68,7 @@ fn test_ops_count(
 
 fn main() -> anyhow::Result<()> {
     let n = 1000000;
-    let capacity = 128<<20;
+    let capacity = 128 << 20;
     let xs = (0..n)
         .map(|i| (Key::single(i, i, TagSet::empty()), i))
         .collect::<Vec<_>>();

--- a/banyan-utils/examples/filter_tiny.rs
+++ b/banyan-utils/examples/filter_tiny.rs
@@ -51,6 +51,7 @@ impl<L, S: BlockWriter<L> + Send + Sync> BlockWriter<L> for OpsCountingStore<S> 
     }
 }
 
+#[allow(clippy::clippy::type_complexity)]
 fn test_ops_count(
     name: &str,
     forest: &Forest<TT, u64, OpsCountingStore<MemStore<Sha256Digest>>>,
@@ -75,10 +76,7 @@ fn main() -> anyhow::Result<()> {
     let store = MemStore::new(usize::max_value(), Sha256Digest::digest);
     let store = OpsCountingStore::new(store);
     let branch_cache = BranchCache::<TT>::new(capacity);
-    let txn = Transaction::new(
-        Forest::new(store.clone(), branch_cache.clone()),
-        store.clone(),
-    );
+    let txn = Transaction::new(Forest::new(store.clone(), branch_cache), store);
     let config = Config {
         target_leaf_size: 1 << 14,
         max_leaf_count: 1 << 12,

--- a/banyan-utils/examples/filter_tiny.rs
+++ b/banyan-utils/examples/filter_tiny.rs
@@ -1,0 +1,102 @@
+use std::{
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+    time::{Duration, Instant},
+};
+
+use banyan::{
+    query::{OffsetRangeQuery, Query},
+    store::{BlockWriter, BranchCache, MemStore, ReadOnlyStore},
+    Config, Forest, Secrets, StreamBuilder, Transaction, Tree,
+};
+use banyan_utils::{
+    tag_index::TagSet,
+    tags::{Key, Sha256Digest, TT},
+};
+
+#[derive(Clone)]
+struct OpsCountingStore<S> {
+    inner: S,
+    reads: Arc<AtomicU64>,
+    writes: Arc<AtomicU64>,
+}
+
+impl<S> OpsCountingStore<S> {
+    fn new(inner: S) -> Self {
+        Self {
+            inner,
+            reads: Arc::new(AtomicU64::default()),
+            writes: Arc::new(AtomicU64::default()),
+        }
+    }
+
+    fn reads(&self) -> u64 {
+        self.reads.load(Ordering::SeqCst)
+    }
+}
+
+impl<L, S: ReadOnlyStore<L>> ReadOnlyStore<L> for OpsCountingStore<S> {
+    fn get(&self, link: &L) -> anyhow::Result<Box<[u8]>> {
+        self.reads.fetch_add(1, Ordering::SeqCst);
+        self.inner.get(link)
+    }
+}
+
+impl<L, S: BlockWriter<L> + Send + Sync> BlockWriter<L> for OpsCountingStore<S> {
+    fn put(&self, data: Vec<u8>) -> anyhow::Result<L> {
+        self.writes.fetch_add(1, Ordering::SeqCst);
+        self.inner.put(data)
+    }
+}
+
+fn test_ops_count(
+    name: &str,
+    forest: &Forest<TT, u64, OpsCountingStore<MemStore<Sha256Digest>>>,
+    tree: &Tree<TT>,
+    query: impl Query<TT> + Clone + 'static,
+) -> (Vec<anyhow::Result<(u64, Key, u64)>>, Duration, u64) {
+    let r0 = forest.store().reads();
+    let t0 = Instant::now();
+    let xs: Vec<anyhow::Result<(u64, Key, u64)>> = forest.iter_filtered(&tree, query).collect();
+    let dt = t0.elapsed();
+    let dr = forest.store().reads() - r0;
+    println!("{} {} {}", name, dr, dt.as_micros());
+    (xs, dt, dr)
+}
+
+fn main() -> anyhow::Result<()> {
+    let n = 1000000;
+    let capacity = 128<<20;
+    let xs = (0..n)
+        .map(|i| (Key::single(i, i, TagSet::empty()), i))
+        .collect::<Vec<_>>();
+    let store = MemStore::new(usize::max_value(), Sha256Digest::digest);
+    let store = OpsCountingStore::new(store);
+    let branch_cache = BranchCache::<TT>::new(capacity);
+    let txn = Transaction::new(
+        Forest::new(store.clone(), branch_cache.clone()),
+        store.clone(),
+    );
+    let config = Config {
+        target_leaf_size: 1 << 14,
+        max_leaf_count: 1 << 14,
+        max_branch_count: 32,
+        zstd_level: 10,
+        max_uncompressed_leaf_size: 16 * 1024 * 1024,
+    };
+    let mut builder = StreamBuilder::new(config, Secrets::default());
+    txn.extend(&mut builder, xs)?;
+    let tree = builder.snapshot();
+
+    println!("{:?}", tree);
+
+    for _i in 0..1000 {
+        let (xs4, _, r_iter_tiny) = test_ops_count("", &txn, &tree, OffsetRangeQuery::from(0..10));
+        assert!(xs4.len() as u64 == 10);
+        // assert_eq!(r_iter_tiny, 4);
+    }
+
+    Ok(())
+}

--- a/banyan-utils/src/bin/cli.rs
+++ b/banyan-utils/src/bin/cli.rs
@@ -423,9 +423,7 @@ async fn main() -> Result<()> {
                 TagSet::single(Tag::from("fizz")),
             )];
             let query = DnfQuery(tags).boxed();
-            let values: Vec<_> = forest
-                .iter_filtered(&tree, query)
-                .collect::<Vec<_>>();
+            let values: Vec<_> = forest.iter_filtered(&tree, query).collect::<Vec<_>>();
             println!("{}", values.len());
             let t1 = std::time::Instant::now();
             let tfilter_common = t1 - t0;
@@ -436,9 +434,7 @@ async fn main() -> Result<()> {
                 TagSet::single(Tag::from("fizzbuzz")),
             )];
             let query = DnfQuery(tags).boxed();
-            let values: Vec<_> = forest
-                .iter_filtered(&tree, query)
-                .collect::<Vec<_>>();
+            let values: Vec<_> = forest.iter_filtered(&tree, query).collect::<Vec<_>>();
             println!("{}", values.len());
             let t1 = std::time::Instant::now();
             let tfilter_rare = t1 - t0;

--- a/banyan-utils/src/tags.rs
+++ b/banyan-utils/src/tags.rs
@@ -326,6 +326,10 @@ impl CompactSeq for KeySeq {
     fn len(&self) -> usize {
         self.tags.elements.len()
     }
+
+    fn estimated_size(&self) -> usize {
+        self.len() * 128
+    }
 }
 
 impl Summarizable<Key> for KeySeq {

--- a/banyan-utils/src/tags.rs
+++ b/banyan-utils/src/tags.rs
@@ -6,7 +6,7 @@ use libipld::{
     codec::{Decode, Encode},
     Cid, DagCbor,
 };
-use multihash::MultihashDigest;
+use multihash::{Code, MultihashDigest};
 use serde::{Deserialize, Serialize};
 use std::{
     convert::{TryFrom, TryInto},
@@ -37,6 +37,11 @@ impl Encode<DagCborCodec> for Sha256Digest {
 impl Sha256Digest {
     pub fn new(data: &[u8]) -> Self {
         let mh = multihash::Code::Sha2_256.digest(data);
+        Sha256Digest(mh.digest().try_into().unwrap())
+    }
+
+    pub fn digest(data: &[u8]) -> Self {
+        let mh = Code::Sha2_256.digest(data);
         Sha256Digest(mh.digest().try_into().unwrap())
     }
 }

--- a/banyan-utils/tests/ops_counting.rs
+++ b/banyan-utils/tests/ops_counting.rs
@@ -104,29 +104,3 @@ fn ops_count_1() -> anyhow::Result<()> {
 
     Ok(())
 }
-
-#[test]
-fn ops_count_2() -> anyhow::Result<()> {
-    let n = 1000000;
-    let capacity = 0;
-    let xs = (0..n)
-        .map(|i| (Key::single(i, i, TagSet::empty()), i))
-        .collect::<Vec<_>>();
-    let store = MemStore::new(usize::max_value(), Sha256Digest::digest);
-    let store = OpsCountingStore::new(store);
-    let branch_cache = BranchCache::<TT>::new(capacity);
-    let txn = Transaction::new(
-        Forest::new(store.clone(), branch_cache.clone()),
-        store.clone(),
-    );
-    let mut builder = StreamBuilder::new(Config::debug_fast(), Secrets::default());
-    txn.extend(&mut builder, xs)?;
-    let tree = builder.snapshot();
-    let (xs4, _, r_iter_tiny) = test_ops_count("", &txn, &tree, OffsetRangeQuery::from(0..10));
-
-    assert!(xs4.len() as u64 == 10);
-
-    assert_eq!(r_iter_tiny, 4);
-
-    Ok(())
-}

--- a/banyan-utils/tests/ops_counting.rs
+++ b/banyan-utils/tests/ops_counting.rs
@@ -51,6 +51,7 @@ impl<L, S: BlockWriter<L> + Send + Sync> BlockWriter<L> for OpsCountingStore<S> 
     }
 }
 
+#[allow(clippy::clippy::type_complexity)]
 fn test_ops_count(
     name: &str,
     forest: &Forest<TT, u64, OpsCountingStore<MemStore<Sha256Digest>>>,
@@ -76,10 +77,7 @@ fn ops_count_1() -> anyhow::Result<()> {
     let store = MemStore::new(usize::max_value(), Sha256Digest::digest);
     let store = OpsCountingStore::new(store);
     let branch_cache = BranchCache::<TT>::new(capacity);
-    let txn = Transaction::new(
-        Forest::new(store.clone(), branch_cache.clone()),
-        store.clone(),
-    );
+    let txn = Transaction::new(Forest::new(store.clone(), branch_cache), store.clone());
     let mut builder = StreamBuilder::new(Config::debug_fast(), Secrets::default());
     txn.extend(&mut builder, xs)?;
     let tree = builder.snapshot();

--- a/banyan-utils/tests/ops_counting.rs
+++ b/banyan-utils/tests/ops_counting.rs
@@ -1,40 +1,31 @@
-use banyan::{
-    index::{BranchIndex, Index, LeafIndex},
-    query::{AllQuery, EmptyQuery, OffsetRangeQuery},
-    store::{BlockWriter, BranchCache, MemStore, ReadOnlyStore},
-    Config, Forest, Secrets, StreamBuilder, Transaction,
-};
-use common::{create_test_tree, txn, IterExt, Key, KeySeq, Sha256Digest, TT};
-use futures::prelude::*;
-use libipld::{cbor::DagCborCodec, codec::Codec, Cid};
-use quickcheck::TestResult;
-use quickcheck_macros::quickcheck;
 use std::{
-    convert::TryInto,
-    iter,
-    ops::Range,
-    str::FromStr,
+    num::NonZeroUsize,
     sync::{
         atomic::{AtomicU64, Ordering},
         Arc,
     },
     time::Instant,
-    usize,
 };
 
-use crate::common::no_offset_overlap;
-
-mod common;
+use banyan::{
+    query::{AllQuery, OffsetRangeQuery},
+    store::{BlockWriter, BranchCache, MemStore, ReadOnlyStore},
+    Config, Forest, Secrets, StreamBuilder, Transaction,
+};
+use banyan_utils::{
+    tag_index::TagSet,
+    tags::{Key, Sha256Digest, TT},
+};
 
 #[derive(Clone)]
-struct OpsCountingStore {
-    inner: MemStore<Sha256Digest>,
+struct OpsCountingStore<S> {
+    inner: S,
     reads: Arc<AtomicU64>,
     writes: Arc<AtomicU64>,
 }
 
-impl OpsCountingStore {
-    fn new(inner: MemStore<Sha256Digest>) -> Self {
+impl<S> OpsCountingStore<S> {
+    fn new(inner: S) -> Self {
         Self {
             inner,
             reads: Arc::new(AtomicU64::default()),
@@ -51,15 +42,15 @@ impl OpsCountingStore {
     }
 }
 
-impl ReadOnlyStore<Sha256Digest> for OpsCountingStore {
-    fn get(&self, link: &Sha256Digest) -> anyhow::Result<Box<[u8]>> {
+impl<L, S: ReadOnlyStore<L>> ReadOnlyStore<L> for OpsCountingStore<S> {
+    fn get(&self, link: &L) -> anyhow::Result<Box<[u8]>> {
         self.reads.fetch_add(1, Ordering::SeqCst);
         self.inner.get(link)
     }
 }
 
-impl BlockWriter<Sha256Digest> for OpsCountingStore {
-    fn put(&self, data: Vec<u8>) -> anyhow::Result<Sha256Digest> {
+impl<L, S: BlockWriter<L> + Send + Sync> BlockWriter<L> for OpsCountingStore<S> {
+    fn put(&self, data: Vec<u8>) -> anyhow::Result<L> {
         self.writes.fetch_add(1, Ordering::SeqCst);
         self.inner.put(data)
     }
@@ -68,26 +59,36 @@ impl BlockWriter<Sha256Digest> for OpsCountingStore {
 #[test]
 fn ops_count_1() -> anyhow::Result<()> {
     let n = 1000000;
-    let xs = (0..n).map(|i| (Key(i), i)).collect::<Vec<_>>();
-    let store = OpsCountingStore::new(MemStore::new(usize::max_value(), Sha256Digest::digest));
-    let branch_cache = BranchCache::<TT>::default();
-    let txn = Transaction::new(Forest::new(store.clone(), branch_cache), store.clone());
+    let capacity = NonZeroUsize::new(128 << 20).unwrap();
+    let xs = (0..n)
+        .map(|i| (Key::single(i, i, TagSet::empty()), i))
+        .collect::<Vec<_>>();
+    let store = MemStore::new(usize::max_value(), Sha256Digest::digest);
+    let store = OpsCountingStore::new(store);
+    let branch_cache = BranchCache::<TT>::new(capacity.into());
+    let txn = Transaction::new(
+        Forest::new(store.clone(), branch_cache.clone()),
+        store.clone(),
+    );
     let mut builder = StreamBuilder::new(Config::debug_fast(), Secrets::default());
     txn.extend(&mut builder, xs)?;
     let tree = builder.snapshot();
 
+    // branch_cache.reset(capacity);
     let t0 = Instant::now();
     let r0 = store.reads();
     let xs1 = txn.collect(&tree)?;
     let r_collect = store.reads() - r0;
     let t_collect = t0.elapsed();
 
+    // branch_cache.reset(capacity);
     let t0 = Instant::now();
     let r0 = store.reads();
     let xs2: Vec<_> = txn.iter_filtered(&builder.snapshot(), AllQuery).collect();
     let r_iter = store.reads() - r0;
     let t_iter = t0.elapsed();
 
+    // branch_cache.reset(capacity);
     let t0 = Instant::now();
     let r0 = store.reads();
     let xs3: Vec<_> = txn

--- a/banyan/src/forest/read.rs
+++ b/banyan/src/forest/read.rs
@@ -41,7 +41,7 @@ struct TraverseState<T: TreeTypes> {
     // Branches can not have zero children, so when this is empty we know that we have
     // to initialize it.
     filter: SmallVec<[bool; 64]>,
-
+    // Option to cache a branch to prevent hammering the branch cache
     branch: Option<Branch<T>>,
 }
 

--- a/banyan/src/forest/read.rs
+++ b/banyan/src/forest/read.rs
@@ -154,18 +154,16 @@ where
 
             let info = match &head.info {
                 Some(info) => info.clone(),
-                None => {
-                    match self.forest.load_node(&self.secrets, &head.index) {
-                        Ok(info) => {
-                            let info = Arc::new(info);
-                            head.info = Some(info.clone());
-                            info
-                        }
-                        Err(cause) => {
-                            return Some(Err(cause));
-                        }
+                None => match self.forest.load_node(&self.secrets, &head.index) {
+                    Ok(info) => {
+                        let info = Arc::new(info);
+                        head.info = Some(info.clone());
+                        info
                     }
-                }
+                    Err(cause) => {
+                        return Some(Err(cause));
+                    }
+                },
             };
 
             match Ok(info.as_ref()) {

--- a/banyan/src/forest/read.rs
+++ b/banyan/src/forest/read.rs
@@ -15,7 +15,7 @@ use futures::{prelude::*, stream::BoxStream};
 use libipld::cbor::DagCbor;
 use smallvec::{smallvec, SmallVec};
 
-use std::{iter, ops::Range, sync::Arc, time::Instant};
+use std::{iter, ops::Range, time::Instant};
 #[derive(PartialEq)]
 enum Mode {
     Forward,
@@ -42,7 +42,7 @@ struct TraverseState<T: TreeTypes> {
     // to initialize it.
     filter: SmallVec<[bool; 64]>,
 
-    branch: Option<Arc<Branch<T>>>,
+    branch: Option<Branch<T>>,
 }
 
 impl<T: TreeTypes> TraverseState<T> {
@@ -192,9 +192,8 @@ where
                                 Err(cause) => return Some(Err(cause)),
                                 _ => panic!(),
                             };
-                            let res = Arc::new(branch);
-                            head.branch = Some(res.clone());
-                            res
+                            head.branch = Some(branch.clone());
+                            branch
                         }
                     };
 
@@ -380,9 +379,7 @@ where
         if let Some(link) = &index.link {
             let res = self.branch_cache().get(link);
             match res {
-                Some(branch) => {
-                    Ok(Some(branch))
-                },
+                Some(branch) => Ok(Some(branch)),
                 None => {
                     let branch = self.load_branch(secrets, index)?;
                     if let Some(branch) = &branch {

--- a/banyan/src/store/mod.rs
+++ b/banyan/src/store/mod.rs
@@ -207,4 +207,11 @@ impl<T: TreeTypes> BranchCache<T> {
             tracing::warn!("Adding {} to cache failed: {}", link, e);
         }
     }
+
+    pub fn reset(&self, capacity: NonZeroUsize) {
+        if let Some(cache) = self.0.as_ref() {
+            let mut cache = cache.lock();
+            *cache = WeightCache::new(capacity);
+        }
+    }
 }

--- a/banyan/tests/common.rs
+++ b/banyan/tests/common.rs
@@ -4,7 +4,7 @@ use banyan::{
     index::{CompactSeq, Summarizable},
     query::AllQuery,
     store::{BranchCache, MemStore, ReadOnlyStore},
-    StreamBuilder, Transaction, Tree, TreeTypes,
+    Config, StreamBuilder, Transaction, Tree, TreeTypes,
 };
 use futures::Future;
 use libipld::{
@@ -101,10 +101,10 @@ where
 {
     let store = MemStore::new(usize::max_value(), Sha256Digest::digest);
     let forest = txn(store, 1000);
-    let mut tree = StreamBuilder::<TT>::debug();
-    forest.extend(&mut tree, xs)?;
-    forest.assert_invariants(&tree)?;
-    Ok((tree.snapshot(), forest))
+    let mut builder = StreamBuilder::<TT>::debug();
+    forest.extend(&mut builder, xs)?;
+    forest.assert_invariants(&builder)?;
+    Ok((builder.snapshot(), forest))
 }
 
 /// Extract all links from a tree

--- a/banyan/tests/common.rs
+++ b/banyan/tests/common.rs
@@ -4,7 +4,7 @@ use banyan::{
     index::{CompactSeq, Summarizable},
     query::AllQuery,
     store::{BranchCache, MemStore, ReadOnlyStore},
-    Config, StreamBuilder, Transaction, Tree, TreeTypes,
+    StreamBuilder, Transaction, Tree, TreeTypes,
 };
 use futures::Future;
 use libipld::{

--- a/banyan/tests/ops_counting.rs
+++ b/banyan/tests/ops_counting.rs
@@ -1,0 +1,111 @@
+use banyan::{
+    index::{BranchIndex, Index, LeafIndex},
+    query::{AllQuery, EmptyQuery, OffsetRangeQuery},
+    store::{BlockWriter, BranchCache, MemStore, ReadOnlyStore},
+    Config, Forest, Secrets, StreamBuilder, Transaction,
+};
+use common::{create_test_tree, txn, IterExt, Key, KeySeq, Sha256Digest, TT};
+use futures::prelude::*;
+use libipld::{cbor::DagCborCodec, codec::Codec, Cid};
+use quickcheck::TestResult;
+use quickcheck_macros::quickcheck;
+use std::{
+    convert::TryInto,
+    iter,
+    ops::Range,
+    str::FromStr,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+    time::Instant,
+    usize,
+};
+
+use crate::common::no_offset_overlap;
+
+mod common;
+
+#[derive(Clone)]
+struct OpsCountingStore {
+    inner: MemStore<Sha256Digest>,
+    reads: Arc<AtomicU64>,
+    writes: Arc<AtomicU64>,
+}
+
+impl OpsCountingStore {
+    fn new(inner: MemStore<Sha256Digest>) -> Self {
+        Self {
+            inner,
+            reads: Arc::new(AtomicU64::default()),
+            writes: Arc::new(AtomicU64::default()),
+        }
+    }
+
+    fn reads(&self) -> u64 {
+        self.reads.load(Ordering::SeqCst)
+    }
+
+    fn writes(&self) -> u64 {
+        self.writes.load(Ordering::SeqCst)
+    }
+}
+
+impl ReadOnlyStore<Sha256Digest> for OpsCountingStore {
+    fn get(&self, link: &Sha256Digest) -> anyhow::Result<Box<[u8]>> {
+        self.reads.fetch_add(1, Ordering::SeqCst);
+        self.inner.get(link)
+    }
+}
+
+impl BlockWriter<Sha256Digest> for OpsCountingStore {
+    fn put(&self, data: Vec<u8>) -> anyhow::Result<Sha256Digest> {
+        self.writes.fetch_add(1, Ordering::SeqCst);
+        self.inner.put(data)
+    }
+}
+
+#[test]
+fn ops_count_1() -> anyhow::Result<()> {
+    let n = 1000000;
+    let xs = (0..n).map(|i| (Key(i), i)).collect::<Vec<_>>();
+    let store = OpsCountingStore::new(MemStore::new(usize::max_value(), Sha256Digest::digest));
+    let branch_cache = BranchCache::<TT>::default();
+    let txn = Transaction::new(Forest::new(store.clone(), branch_cache), store.clone());
+    let mut builder = StreamBuilder::new(Config::debug_fast(), Secrets::default());
+    txn.extend(&mut builder, xs)?;
+    let tree = builder.snapshot();
+
+    let t0 = Instant::now();
+    let r0 = store.reads();
+    let xs1 = txn.collect(&tree)?;
+    let r_collect = store.reads() - r0;
+    let t_collect = t0.elapsed();
+
+    let t0 = Instant::now();
+    let r0 = store.reads();
+    let xs2: Vec<_> = txn.iter_filtered(&builder.snapshot(), AllQuery).collect();
+    let r_iter = store.reads() - r0;
+    let t_iter = t0.elapsed();
+
+    let t0 = Instant::now();
+    let r0 = store.reads();
+    let xs3: Vec<_> = txn
+        .iter_filtered(&builder.snapshot(), OffsetRangeQuery::from(0..n / 10))
+        .collect();
+    let r_iter_10 = store.reads() - r0;
+    let t_iter_10 = t0.elapsed();
+
+    assert!(xs1.len() as u64 == n);
+    assert!(xs2.len() as u64 == n);
+    assert!(xs3.len() as u64 == n / 10);
+
+    println!("{} {} {}", r_collect, r_iter, r_iter_10);
+    println!(
+        "{} {} {}",
+        t_collect.as_micros(),
+        t_iter.as_micros(),
+        t_iter_10.as_micros()
+    );
+    Ok(())
+}


### PR DESCRIPTION
Due to the conversion from a recursive traversal to an iterator, the load_node function was called many times, causing perf problems. This fixes this by caching that call and doing a few other things to optimize traversal.

There is a test that makes sure we only request a small number of blocks when drilling down to a single value.

Traversal with a query that matches everything is now a tiny bit slower than collect, and traversal of a tiny section of the tree is fast as expected.

Still something weird that deserves looking into:

```
running 1 test
collect 65 reads, 236798us
iter    65 reads, 282631us
small   35 reads, 131453us
tiny    35 reads, 110551us < this should not be 35 reads...
test ops_count_1 ... ok
```

Now this is looking better:

```
create 1.372394
collect 0.2854
filter_common 0.176785
filter_rare 0.084883
```