### PR TITLE
NodeInfo and type parameter refactoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "banyan"
-version = "0.13.0"
+version = "0.13.0-rc.2"
 dependencies = [
  "anyhow",
  "chacha20",
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "banyan-utils"
-version = "0.6.0"
+version = "0.6.0-rc.2"
 dependencies = [
  "anyhow",
  "banyan",

--- a/banyan-utils/Cargo.toml
+++ b/banyan-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "banyan-utils"
-version = "0.6.0"
+version = "0.6.0-rc.2"
 authors = ["Rüdiger Klaehn <rklaehn@protonmail.com>", "Actyx AG"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -18,7 +18,7 @@ path = "src/bin/cli.rs"
 
 [dependencies]
 anyhow = "1.0.40"
-banyan = { version = "0.13.0", path = "../banyan" }
+banyan = { version = "0.13.0-rc.2", path = "../banyan" }
 base64 = "0.13.0"
 chacha20 = "0.7.1"
 derive_more = "0.99.13"

--- a/banyan-utils/examples/filter_tiny.rs
+++ b/banyan-utils/examples/filter_tiny.rs
@@ -56,8 +56,8 @@ impl<L, S: BlockWriter<L> + Send + Sync> BlockWriter<L> for OpsCountingStore<S> 
 #[allow(clippy::clippy::type_complexity)]
 fn test_ops_count(
     name: &str,
-    forest: &Forest<TT, u64, OpsCountingStore<MemStore<Sha256Digest>>>,
-    tree: &Tree<TT>,
+    forest: &Forest<TT, OpsCountingStore<MemStore<Sha256Digest>>>,
+    tree: &Tree<TT, u64>,
     query: impl Query<TT> + Clone + 'static,
 ) -> (Vec<anyhow::Result<(u64, Key, u64)>>, Duration, u64) {
     let r0 = forest.store().reads();

--- a/banyan-utils/src/bin/cli.rs
+++ b/banyan-utils/src/bin/cli.rs
@@ -2,13 +2,13 @@ use futures::future::poll_fn;
 use futures::prelude::*;
 use ipfs_sqlite_block_store::BlockStore;
 
-use std::{collections::BTreeMap, str::FromStr, sync::Arc, time::Duration};
+use std::{collections::BTreeMap, str::FromStr, time::Duration};
 use structopt::StructOpt;
 use tracing::Level;
 
 use banyan::{
     query::{AllQuery, OffsetRangeQuery, QueryExt},
-    store::{ArcBlockWriter, ArcReadOnlyStore, BlockWriter, BranchCache, MemStore, ReadOnlyStore},
+    store::{BlockWriter, BranchCache, MemStore, ReadOnlyStore},
     Config, Forest, Secrets, StreamBuilder, Transaction, Tree,
 };
 use banyan_utils::{
@@ -27,8 +27,9 @@ static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 pub type Error = anyhow::Error;
 pub type Result<T> = anyhow::Result<T>;
 
-type Txn = Transaction<TT, String, ArcReadOnlyStore<Sha256Digest>, ArcBlockWriter<Sha256Digest>>;
+type Txn = Transaction<TT, Storage, Storage>;
 
+#[derive(Clone)]
 enum Storage {
     Memory(MemStore<Sha256Digest>),
     Ipfs(IpfsStore),
@@ -222,7 +223,7 @@ async fn build_tree(
     count: u64,
     unbalanced: bool,
     print_every: u64,
-) -> anyhow::Result<StreamBuilder<TT>> {
+) -> anyhow::Result<StreamBuilder<TT, String>> {
     let secrets = Secrets::default();
     let config = Config::debug();
     let mut tagger = Tagger::new();
@@ -242,7 +243,7 @@ async fn build_tree(
     };
     let mut tree = match base {
         Some(root) => forest.load_stream_builder(secrets, config, root)?,
-        None => StreamBuilder::<TT>::new(config, secrets),
+        None => StreamBuilder::<TT, String>::new(config, secrets),
     };
     let mut offset: u64 = 0;
     for _ in 0..batches {
@@ -278,7 +279,7 @@ async fn bench_build(
     unbalanced: bool,
     secrets: Secrets,
     config: Config,
-) -> anyhow::Result<(Tree<TT>, std::time::Duration)> {
+) -> anyhow::Result<(Tree<TT, String>, std::time::Duration)> {
     let mut tagger = Tagger::new();
     // function to add some arbitrary tags to test out tag querying and compression
     let mut tags_from_offset = |i: u64| -> TagSet {
@@ -296,7 +297,7 @@ async fn bench_build(
     };
     let mut tree = match base {
         Some(link) => forest.load_stream_builder(secrets, config, link)?,
-        None => StreamBuilder::<TT>::new(config, secrets),
+        None => StreamBuilder::<TT, String>::new(config, secrets),
     };
     let mut offset: u64 = 0;
     let data = (0..batches)
@@ -346,7 +347,7 @@ async fn main() -> Result<()> {
         }
     };
 
-    let store = Arc::new(opts.storage);
+    let store = opts.storage;
     let index_key: chacha20::Key = opts.index_pass.map(create_chacha_key).unwrap_or_default();
     let value_key: chacha20::Key = opts.value_pass.map(create_chacha_key).unwrap_or_default();
     let config = Config::debug_fast();
@@ -360,16 +361,16 @@ async fn main() -> Result<()> {
     let forest = txn();
     match opts.cmd {
         Command::Graph { root } => {
-            let tree = forest.load_tree(secrets, root)?;
+            let tree = forest.load_tree::<String>(secrets, root)?;
             let mut stdout = std::io::stdout();
             dump::graph(&forest, &tree, &mut stdout)?;
         }
         Command::Dump { root } => {
-            let tree = forest.load_tree(secrets, root)?;
+            let tree = forest.load_tree::<String>(secrets, root)?;
             forest.dump(&tree)?;
         }
         Command::DumpValues { root } => {
-            let tree = forest.load_tree(secrets, root)?;
+            let tree = forest.load_tree::<String>(secrets, root)?;
             let iter = forest.iter_from(&tree);
             for res in iter {
                 let (i, k, v) = res?;
@@ -380,7 +381,7 @@ async fn main() -> Result<()> {
             dump::dump_json(store, hash, value_key, &mut std::io::stdout())?;
         }
         Command::Stream { root } => {
-            let tree = forest.load_tree(secrets, root)?;
+            let tree = forest.load_tree::<String>(secrets, root)?;
             let mut stream = forest.stream_filtered(&tree, AllQuery).enumerate();
             while let Some((i, Ok(v))) = stream.next().await {
                 if i % 1000 == 0 {
@@ -457,7 +458,7 @@ async fn main() -> Result<()> {
             let query = DnfQuery(tags).boxed();
             let secrets = Secrets::default();
             let config = Config::debug();
-            let tree = forest.load_stream_builder(secrets, config, root)?;
+            let tree = forest.load_stream_builder::<String>(secrets, config, root)?;
             forest.dump(&tree.snapshot())?;
             let mut stream = forest.stream_filtered(&tree.snapshot(), query).enumerate();
             while let Some((i, Ok(v))) = stream.next().await {
@@ -469,7 +470,7 @@ async fn main() -> Result<()> {
         Command::Forget { root, before } => {
             let secrets = Secrets::default();
             let config = Config::debug();
-            let mut tree = forest.load_stream_builder(secrets, config, root)?;
+            let mut tree = forest.load_stream_builder::<String>(secrets, config, root)?;
             forest.retain(&mut tree, &OffsetRangeQuery::from(before..))?;
             forest.dump(&tree.snapshot())?;
             println!("{:?}", tree);
@@ -477,7 +478,7 @@ async fn main() -> Result<()> {
         Command::Pack { root } => {
             let secrets = Secrets::default();
             let config = Config::debug();
-            let mut tree = forest.load_stream_builder(secrets, config, root)?;
+            let mut tree = forest.load_stream_builder::<String>(secrets, config, root)?;
             forest.dump(&tree.snapshot())?;
             forest.pack(&mut tree)?;
             forest.assert_invariants(&tree)?;
@@ -496,7 +497,7 @@ async fn main() -> Result<()> {
                 let forest = forest2.clone();
                 let secrets = secrets.clone();
                 future::ready(
-                    link.and_then(move |link| forest.load_tree(secrets, link))
+                    link.and_then(move |link| forest.load_tree::<String>(secrets, link))
                         .ok(),
                 )
             });
@@ -506,14 +507,14 @@ async fn main() -> Result<()> {
             }
         }
         Command::Repair { root } => {
-            let mut tree = forest.load_stream_builder(secrets, config, root)?;
+            let mut tree = forest.load_stream_builder::<String>(secrets, config, root)?;
             let _ = forest.repair(&mut tree)?;
             forest.dump(&tree.snapshot())?;
             println!("{:?}", tree);
         }
         Command::SendStream { topic } => {
             let mut ticks = tokio::time::interval(Duration::from_secs(1));
-            let mut tree = StreamBuilder::<TT>::new(config, secrets);
+            let mut tree = StreamBuilder::<TT, String>::new(config, secrets);
             let mut offset = 0;
             loop {
                 poll_fn(|cx| ticks.poll_tick(cx)).await;

--- a/banyan-utils/src/dump.rs
+++ b/banyan-utils/src/dump.rs
@@ -2,7 +2,7 @@ use core::fmt::Debug;
 use std::collections::BTreeMap;
 
 use banyan::{
-    store::{ArcReadOnlyStore, ReadOnlyStore, ZstdDagCborSeq},
+    store::{ReadOnlyStore, ZstdDagCborSeq},
     Tree, {Forest, TreeTypes},
 };
 use libipld::{cbor::DagCbor, codec::Codec, json::DagJsonCodec};
@@ -101,8 +101,8 @@ impl<'a> dot::GraphWalk<'a, Node<'a>, Edge<'a>> for ForestWithTree {
 }
 
 pub fn graph<TT, V, R>(
-    forest: &Forest<TT, V, R>,
-    tree: &Tree<TT>,
+    forest: &Forest<TT, R>,
+    tree: &Tree<TT, V>,
     mut out: impl std::io::Write,
 ) -> anyhow::Result<()>
 where
@@ -134,8 +134,8 @@ where
 
 /// Takes a hash to a dagcbor encoded blob, and write it as dag-json to `writer`,
 /// each item separated by newlines.
-pub fn dump_json<Link>(
-    store: ArcReadOnlyStore<Link>,
+pub fn dump_json<Link: 'static>(
+    store: impl ReadOnlyStore<Link>,
     hash: Link,
     value_key: chacha20::Key,
     mut writer: impl std::io::Write,

--- a/banyan-utils/src/dump.rs
+++ b/banyan-utils/src/dump.rs
@@ -111,14 +111,14 @@ where
     R: ReadOnlyStore<TT::Link> + Clone + Send + Sync + 'static,
 {
     let (edges, nodes) = forest.dump_graph(&tree, |(id, node)| match node {
-        banyan::index::NodeInfo2::Branch(idx, _) | banyan::index::NodeInfo2::PurgedBranch(idx) => {
+        banyan::index::NodeInfo::Branch(idx, _) | banyan::index::NodeInfo::PurgedBranch(idx) => {
             NodeDescriptor::Branch {
                 level: idx.level as usize,
                 id,
                 sealed: idx.sealed,
             }
         }
-        banyan::index::NodeInfo2::Leaf(idx, _) | banyan::index::NodeInfo2::PurgedLeaf(idx) => {
+        banyan::index::NodeInfo::Leaf(idx, _) | banyan::index::NodeInfo::PurgedLeaf(idx) => {
             NodeDescriptor::Leaf {
                 id,
                 items: idx.keys().fold(0, |acc, _| acc + 1),

--- a/banyan-utils/src/dump.rs
+++ b/banyan-utils/src/dump.rs
@@ -111,14 +111,14 @@ where
     R: ReadOnlyStore<TT::Link> + Clone + Send + Sync + 'static,
 {
     let (edges, nodes) = forest.dump_graph(&tree, |(id, node)| match node {
-        banyan::index::NodeInfo::Branch(idx, _) | banyan::index::NodeInfo::PurgedBranch(idx) => {
+        banyan::index::NodeInfo2::Branch(idx, _) | banyan::index::NodeInfo2::PurgedBranch(idx) => {
             NodeDescriptor::Branch {
                 level: idx.level as usize,
                 id,
                 sealed: idx.sealed,
             }
         }
-        banyan::index::NodeInfo::Leaf(idx, _) | banyan::index::NodeInfo::PurgedLeaf(idx) => {
+        banyan::index::NodeInfo2::Leaf(idx, _) | banyan::index::NodeInfo2::PurgedLeaf(idx) => {
             NodeDescriptor::Leaf {
                 id,
                 items: idx.keys().fold(0, |acc, _| acc + 1),

--- a/banyan-utils/tests/ops_counting.rs
+++ b/banyan-utils/tests/ops_counting.rs
@@ -78,13 +78,16 @@ fn ops_count_1() -> anyhow::Result<()> {
         zstd_level: 10,
     };
     let n = 1000000;
-    let capacity = 0;
+    // test with a rather large cache, but a new one on every test
+    //
+    // we are interested in the number of distinct blocks being accessed.
+    let capacity = 16 << 20;
     let xs = (0..n)
         .map(|i| (Key::single(i, i, TagSet::empty()), i))
         .collect::<Vec<_>>();
     let store = MemStore::new(usize::max_value(), Sha256Digest::digest);
     let store = OpsCountingStore::new(store);
-    let branch_cache = BranchCache::<TT>::new(capacity);
+    let branch_cache = BranchCache::<TT>::new(0);
     let txn = Transaction::new(Forest::new(store.clone(), branch_cache), store.clone());
     let mut builder = StreamBuilder::new(config, Secrets::default());
     txn.extend(&mut builder, xs)?;
@@ -96,11 +99,24 @@ fn ops_count_1() -> anyhow::Result<()> {
     let r_collect = store.reads() - r0;
     println!("collect {} {}", r_collect, t0.elapsed().as_micros());
 
-    let (xs2, _, r_iter) = test_ops_count("iter   ", &txn, &tree, AllQuery);
-    let (xs3, _, r_iter_small) =
-        test_ops_count("small  ", &txn, &tree, OffsetRangeQuery::from(0..n / 10));
-    let (xs4, _, r_iter_tiny) =
-        test_ops_count("tiny   ", &txn, &tree, OffsetRangeQuery::from(0..10));
+    let (xs2, _, r_iter) = test_ops_count(
+        "iter   ",
+        &Forest::new(store.clone(), BranchCache::new(capacity)),
+        &tree,
+        AllQuery,
+    );
+    let (xs3, _, r_iter_small) = test_ops_count(
+        "small  ",
+        &Forest::new(store.clone(), BranchCache::new(capacity)),
+        &tree,
+        OffsetRangeQuery::from(0..n / 10),
+    );
+    let (xs4, _, r_iter_tiny) = test_ops_count(
+        "tiny   ",
+        &Forest::new(store.clone(), BranchCache::new(capacity)),
+        &tree,
+        OffsetRangeQuery::from(0..10),
+    );
 
     assert!(xs1.len() as u64 == n);
     assert!(xs2.len() as u64 == n);

--- a/banyan-utils/tests/ops_counting.rs
+++ b/banyan-utils/tests/ops_counting.rs
@@ -113,7 +113,7 @@ fn ops_count_1() -> anyhow::Result<()> {
     );
     let (xs4, _, r_iter_tiny) = test_ops_count(
         "tiny   ",
-        &Forest::new(store.clone(), BranchCache::new(capacity)),
+        &Forest::new(store, BranchCache::new(capacity)),
         &tree,
         OffsetRangeQuery::from(0..10),
     );

--- a/banyan-utils/tests/ops_counting.rs
+++ b/banyan-utils/tests/ops_counting.rs
@@ -54,8 +54,8 @@ impl<L, S: BlockWriter<L> + Send + Sync> BlockWriter<L> for OpsCountingStore<S> 
 #[allow(clippy::clippy::type_complexity)]
 fn test_ops_count(
     name: &str,
-    forest: &Forest<TT, u64, OpsCountingStore<MemStore<Sha256Digest>>>,
-    tree: &Tree<TT>,
+    forest: &Forest<TT, OpsCountingStore<MemStore<Sha256Digest>>>,
+    tree: &Tree<TT, u64>,
     query: impl Query<TT> + Clone + 'static,
 ) -> (Vec<anyhow::Result<(u64, Key, u64)>>, Duration, u64) {
     let r0 = forest.store().reads();

--- a/banyan/Cargo.toml
+++ b/banyan/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "banyan"
-version = "0.13.0"
+version = "0.13.0-rc.2"
 authors = ["Rüdiger Klaehn <rklaehn@protonmail.com>", "Actyx AG"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/banyan/src/forest/index_iter.rs
+++ b/banyan/src/forest/index_iter.rs
@@ -60,7 +60,7 @@ impl<T, R, Q> IndexIter<T, R, Q>
 where
     T: TreeTypes,
     R: ReadOnlyStore<T::Link>,
-    Q: Query<T> + Clone + Send + 'static,
+    Q: Query<T>,
 {
     pub(crate) fn new(forest: Forest<T, R>, secrets: Secrets, query: Q, index: Index<T>) -> Self {
         let mode = Mode::Forward;
@@ -100,7 +100,7 @@ impl<T, R, Q> Iterator for IndexIter<T, R, Q>
 where
     T: TreeTypes,
     R: ReadOnlyStore<T::Link>,
-    Q: Query<T> + Clone + Send + 'static,
+    Q: Query<T>,
 {
     type Item = Result<Index<T>>;
 

--- a/banyan/src/forest/mod.rs
+++ b/banyan/src/forest/mod.rs
@@ -267,17 +267,17 @@ pub(crate) enum CreateMode {
 /// A filtered chunk.
 /// Contains both data and information about the offsets the data resulted from.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct FilteredChunk<T: TreeTypes, V, E> {
+pub struct FilteredChunk<V, E> {
     /// index range for this chunk
     pub range: Range<u64>,
 
-    /// filtered data (offset, key, value)
+    /// filtered data
     /// Note that this is always in ascending order, even when traversing a tree
     /// in descending order.
     ///
     /// If no elements were filtered, this will have the same number of elements
     /// as the range.
-    pub data: Vec<(u64, T::Key, V)>,
+    pub data: Vec<V>,
 
     /// arbitrary extra data computed from the leaf or branch index.
     /// If you don't need this you can just pass a fn that returns ()

--- a/banyan/src/forest/mod.rs
+++ b/banyan/src/forest/mod.rs
@@ -48,7 +48,7 @@ pub trait TreeTypes: Debug + Send + Sync + Clone + 'static {
 pub struct ForestInner<T: TreeTypes, V, R> {
     pub(crate) store: R,
     pub(crate) branch_cache: BranchCache<T>,
-    pub(crate) _tt: PhantomData<(T, V, R)>,
+    pub(crate) _tt: PhantomData<V>,
 }
 
 #[derive(Debug)]

--- a/banyan/src/forest/mod.rs
+++ b/banyan/src/forest/mod.rs
@@ -9,7 +9,7 @@ mod read;
 mod stream;
 mod write;
 pub(crate) use index_iter::IndexIter;
-pub(crate) use read::ForestIter;
+pub(crate) use read::TreeIter;
 
 /// Trees can be parametrized with the key type and the sequence type. Also, to avoid a dependency
 /// on a link type with all its baggage, we parameterize the link type.

--- a/banyan/src/forest/read.rs
+++ b/banyan/src/forest/read.rs
@@ -7,7 +7,7 @@ use crate::{
     query::Query,
     store::ReadOnlyStore,
     store::ZstdDagCborSeq,
-    util::{BoolSliceExt, BoxedIter, IterExt},
+    util::{BoolSliceExt, IterExt},
 };
 use anyhow::{anyhow, Result};
 use core::fmt::Debug;
@@ -526,28 +526,26 @@ where
         secrets: Secrets,
         query: Q,
         index: Index<T>,
-    ) -> BoxedIter<'static, Result<(u64, T::Key, V)>> {
+    ) -> impl Iterator<Item = Result<(u64, T::Key, V)>> {
         self.traverse0(secrets, query, index, &|_| {})
             .map(|res| match res {
                 Ok(chunk) => chunk.data.into_iter().map(Ok).left_iter(),
                 Err(cause) => iter::once(Err(cause)).right_iter(),
             })
             .flatten()
-            .boxed()
     }
     pub(crate) fn iter_filtered_reverse0<Q: Query<T> + Clone + Send + 'static>(
         &self,
         secrets: Secrets,
         query: Q,
         index: Index<T>,
-    ) -> BoxedIter<'static, Result<(u64, T::Key, V)>> {
+    ) -> impl Iterator<Item = Result<(u64, T::Key, V)>> {
         self.traverse_rev0(secrets, query, index, &|_| {})
             .map(|res| match res {
                 Ok(chunk) => chunk.data.into_iter().map(Ok).left_iter(),
                 Err(cause) => iter::once(Err(cause)).right_iter(),
             })
             .flatten()
-            .boxed()
     }
 
     pub(crate) fn stream_filtered_chunked_reverse0<

--- a/banyan/src/forest/read.rs
+++ b/banyan/src/forest/read.rs
@@ -73,7 +73,7 @@ where
     T: TreeTypes,
     V: BanyanValue,
     R: ReadOnlyStore<T::Link>,
-    Q: Query<T> + Clone + Send + 'static,
+    Q: Query<T>,
     E: Send + 'static,
     F: Fn(IndexRef<T>) -> E + Send + Sync + 'static,
 {
@@ -273,7 +273,7 @@ where
     T: TreeTypes,
     V: BanyanValue,
     R: ReadOnlyStore<T::Link>,
-    Q: Query<T> + Clone + Send + 'static,
+    Q: Query<T>,
     E: Send + 'static,
     F: Fn(IndexRef<T>) -> E + Send + Sync + 'static,
 {
@@ -492,7 +492,7 @@ where
     /// Convenience method to stream filtered.
     ///
     /// Implemented in terms of stream_filtered_chunked
-    pub(crate) fn stream_filtered0<Q: Query<T> + Clone + 'static, V: BanyanValue>(
+    pub(crate) fn stream_filtered0<Q: Query<T>, V: BanyanValue>(
         &self,
         secrets: Secrets,
         query: Q,
@@ -506,7 +506,7 @@ where
 
     #[allow(clippy::clippy::type_complexity)]
     pub(crate) fn stream_filtered_chunked0<
-        Q: Query<T> + Clone + Send + 'static,
+        Q: Query<T>,
         V: BanyanValue,
         E: Send + 'static,
         F: Fn(IndexRef<T>) -> E + Send + Sync + 'static,
@@ -525,7 +525,7 @@ where
     }
 
     /// Convenience method to iterate filtered.
-    pub(crate) fn iter_filtered0<Q: Query<T> + Clone + Send + 'static, V: BanyanValue>(
+    pub(crate) fn iter_filtered0<Q: Query<T>, V: BanyanValue>(
         &self,
         secrets: Secrets,
         query: Q,
@@ -538,7 +538,7 @@ where
             })
             .flatten()
     }
-    pub(crate) fn iter_filtered_reverse0<Q: Query<T> + Clone + Send + 'static, V: BanyanValue>(
+    pub(crate) fn iter_filtered_reverse0<Q: Query<T>, V: BanyanValue>(
         &self,
         secrets: Secrets,
         query: Q,
@@ -554,7 +554,7 @@ where
 
     #[allow(clippy::clippy::type_complexity)]
     pub(crate) fn stream_filtered_chunked_reverse0<
-        Q: Query<T> + Clone + Send + 'static,
+        Q: Query<T>,
         V: BanyanValue,
         E: Send + 'static,
         F: Fn(IndexRef<T>) -> E + Send + Sync + 'static,

--- a/banyan/src/forest/read.rs
+++ b/banyan/src/forest/read.rs
@@ -142,6 +142,7 @@ where
         }
     }
 
+    #[allow(clippy::type_complexity)]
     fn next_fallible(&mut self) -> Result<Option<FilteredChunk<(u64, T::Key, V), E>>> {
         Ok(Some(loop {
             let head = match self.stack.last_mut() {
@@ -276,6 +277,7 @@ where
     E: Send + 'static,
     F: Fn(IndexRef<T>) -> E + Send + Sync + 'static,
 {
+    #[allow(clippy::type_complexity)]
     type Item = Result<FilteredChunk<(u64, T::Key, V), E>>;
 
     fn next(&mut self) -> Option<<Self as Iterator>::Item> {

--- a/banyan/src/forest/read.rs
+++ b/banyan/src/forest/read.rs
@@ -21,7 +21,7 @@ enum Mode {
     Forward,
     Backward,
 }
-pub(crate) struct ForestIter<T: TreeTypes, V, R, Q: Query<T>, F> {
+pub(crate) struct TreeIter<T: TreeTypes, V, R, Q, F> {
     forest: Forest<T, V, R>,
     secrets: Secrets,
     offset: u64,
@@ -68,7 +68,7 @@ impl<T: TreeTypes> TraverseState<T> {
     }
 }
 
-impl<T: TreeTypes, V, R, Q, E, F> ForestIter<T, V, R, Q, F>
+impl<T: TreeTypes, V, R, Q, E, F> TreeIter<T, V, R, Q, F>
 where
     T: TreeTypes + 'static,
     V: DagCbor + Clone + Send + Sync + Debug + 'static,
@@ -221,7 +221,7 @@ where
                         };
                         break FilteredChunk {
                             range,
-                            data: Vec::new(),
+                            data: vec![],
                             extra: (self.mk_extra)(index.as_index_ref()),
                         };
                     }
@@ -277,7 +277,7 @@ where
     }
 }
 
-impl<T: TreeTypes, V, R, Q, E, F> Iterator for ForestIter<T, V, R, Q, F>
+impl<T: TreeTypes, V, R, Q, E, F> Iterator for TreeIter<T, V, R, Q, F>
 where
     T: TreeTypes + 'static,
     V: DagCbor + Clone + Send + Sync + Debug + 'static,

--- a/banyan/src/forest/read.rs
+++ b/banyan/src/forest/read.rs
@@ -1,8 +1,8 @@
 use super::{BranchCache, Config, FilteredChunk, Forest, Secrets, TreeTypes};
 use crate::{
     index::{
-        deserialize_compressed, Branch, BranchIndex, CompactSeq, Index, IndexRef, Leaf, LeafIndex,
-        NodeInfo,
+        deserialize_compressed, Branch, BranchIndex, BranchInfo, CompactSeq, Index, IndexRef, Leaf,
+        LeafIndex, LeafInfo, NodeInfo, NodeInfo2,
     },
     query::Query,
     store::ReadOnlyStore,
@@ -374,6 +374,29 @@ where
             }
         } else {
             Ok(None)
+        }
+    }
+
+    pub(crate) fn load_node_2<'a>(
+        &'a self,
+        secrets: &'a Secrets,
+        index: &'a Index<T>,
+    ) -> NodeInfo2<'a, T, V, R> {
+        match index {
+            Index::Branch(index) => {
+                if index.link.is_some() {
+                    NodeInfo2::Branch(BranchInfo::new(self, secrets, index))
+                } else {
+                    NodeInfo2::PurgedBranch(index)
+                }
+            }
+            Index::Leaf(index) => {
+                if index.link.is_some() {
+                    NodeInfo2::Leaf(LeafInfo::new(self, secrets, index))
+                } else {
+                    NodeInfo2::PurgedLeaf(index)
+                }
+            }
         }
     }
 

--- a/banyan/src/forest/stream.rs
+++ b/banyan/src/forest/stream.rs
@@ -23,7 +23,7 @@ impl<T: TreeTypes, R: ReadOnlyStore<T::Link>> Forest<T, R> {
         trees: S,
     ) -> impl Stream<Item = anyhow::Result<(u64, T::Key, V)>> + Send
     where
-        Q: Query<T> + Clone + 'static,
+        Q: Query<T> + Clone,
         S: Stream<Item = Tree<T, V>> + Send + 'static,
         V: BanyanValue,
     {
@@ -47,7 +47,7 @@ impl<T: TreeTypes, R: ReadOnlyStore<T::Link>> Forest<T, R> {
     ) -> impl Stream<Item = anyhow::Result<FilteredChunk<(u64, T::Key, V), E>>> + Send + 'static
     where
         S: Stream<Item = Tree<T, V>> + Send + 'static,
-        Q: Query<T> + Clone + Send + 'static,
+        Q: Query<T> + Clone,
         V: BanyanValue,
         E: Send + 'static,
         F: Send + Sync + 'static + Fn(IndexRef<T>) -> E,
@@ -101,7 +101,7 @@ impl<T: TreeTypes, R: ReadOnlyStore<T::Link>> Forest<T, R> {
     ) -> impl Stream<Item = anyhow::Result<FilteredChunk<(u64, T::Key, V), E>>> + Send + 'static
     where
         S: Stream<Item = Tree<T, V>> + Send + 'static,
-        Q: Query<T> + Clone + Send + 'static,
+        Q: Query<T> + Clone,
         V: BanyanValue,
         E: Send + 'static,
         F: Send + Sync + 'static + Fn(IndexRef<T>) -> E,
@@ -148,7 +148,7 @@ impl<T: TreeTypes, R: ReadOnlyStore<T::Link>> Forest<T, R> {
     ) -> impl Stream<Item = anyhow::Result<FilteredChunk<(u64, T::Key, V), E>>> + Send + 'static
     where
         S: Stream<Item = Tree<T, V>> + Send + 'static,
-        Q: Query<T> + Clone + Send + 'static,
+        Q: Query<T> + Clone,
         V: BanyanValue,
         E: Send + 'static,
         F: Send + Sync + 'static + Fn(IndexRef<T>) -> E,

--- a/banyan/src/forest/stream.rs
+++ b/banyan/src/forest/stream.rs
@@ -49,7 +49,7 @@ impl<
         trees: S,
         range: RangeInclusive<u64>,
         mk_extra: &'static F,
-    ) -> impl Stream<Item = anyhow::Result<FilteredChunk<T, V, E>>> + Send + 'static
+    ) -> impl Stream<Item = anyhow::Result<FilteredChunk<(u64, T::Key, V), E>>> + Send + 'static
     where
         Q: Query<T> + Clone + Send + 'static,
         E: Send + 'static,
@@ -102,7 +102,7 @@ impl<
         range: RangeInclusive<u64>,
         mk_extra: &'static F,
         thread_pool: ThreadPool,
-    ) -> impl Stream<Item = anyhow::Result<FilteredChunk<T, V, E>>> + Send + 'static
+    ) -> impl Stream<Item = anyhow::Result<FilteredChunk<(u64, T::Key, V), E>>> + Send + 'static
     where
         Q: Query<T> + Clone + Send + 'static,
         E: Send + 'static,
@@ -148,7 +148,7 @@ impl<
         trees: S,
         range: RangeInclusive<u64>,
         mk_extra: &'static F,
-    ) -> impl Stream<Item = anyhow::Result<FilteredChunk<T, V, E>>> + Send + 'static
+    ) -> impl Stream<Item = anyhow::Result<FilteredChunk<(u64, T::Key, V), E>>> + Send + 'static
     where
         Q: Query<T> + Clone + Send + 'static,
         E: Send + 'static,

--- a/banyan/src/forest/write.rs
+++ b/banyan/src/forest/write.rs
@@ -1,6 +1,6 @@
 use crate::{
     forest::{BranchResult, Config, CreateMode, Forest, Transaction, TreeTypes},
-    index::{zip_with_offset_ref, NodeInfo2},
+    index::{zip_with_offset_ref, NodeInfo},
     store::{BlockWriter, ReadOnlyStore},
     StreamBuilderState,
 };
@@ -292,15 +292,15 @@ where
             return Ok(index.clone());
         }
         let secrets = stream.secrets().clone();
-        Ok(match self.load_node_2(&secrets, index) {
-            NodeInfo2::Leaf(index, mut leaf) => {
+        Ok(match self.load_node(&secrets, index) {
+            NodeInfo::Leaf(index, mut leaf) => {
                 tracing::debug!("extending existing leaf");
                 let leaf = leaf.load()?;
                 let keys = index.keys.clone();
                 self.extend_leaf(leaf.as_ref().compressed(), Some(keys), from, stream)?
                     .into()
             }
-            NodeInfo2::Branch(index, mut branch) => {
+            NodeInfo::Branch(index, mut branch) => {
                 tracing::debug!("extending existing branch");
                 let branch = branch.load()?;
                 let mut children = branch.children.to_vec();
@@ -311,7 +311,7 @@ where
                 self.extend_branch(children, index.level, from, stream, CreateMode::Packed)?
                     .into()
             }
-            NodeInfo2::PurgedBranch(_) | NodeInfo2::PurgedLeaf(_) => {
+            NodeInfo::PurgedBranch(_) | NodeInfo::PurgedLeaf(_) => {
                 // purged nodes can not be extended
                 index.clone()
             }

--- a/banyan/src/forest/write.rs
+++ b/banyan/src/forest/write.rs
@@ -15,24 +15,22 @@ use crate::{
     util::{is_sorted, BoolSliceExt},
 };
 use anyhow::{ensure, Result};
-use core::fmt::Debug;
 use libipld::cbor::DagCbor;
 use std::{iter, time::Instant};
 
 /// basic random access append only tree
-impl<T, V, R, W> Transaction<T, V, R, W>
+impl<T, R, W> Transaction<T, R, W>
 where
-    T: TreeTypes + 'static,
-    V: DagCbor + Clone + Send + Sync + Debug + 'static,
-    R: ReadOnlyStore<T::Link> + Clone + Send + Sync + 'static,
-    W: BlockWriter<T::Link> + 'static,
+    T: TreeTypes,
+    R: ReadOnlyStore<T::Link>,
+    W: BlockWriter<T::Link>,
 {
-    pub fn read(&self) -> &Forest<T, V, R> {
+    pub fn read(&self) -> &Forest<T, R> {
         &self.read
     }
 
     /// create a leaf from scratch from an interator
-    fn leaf_from_iter(
+    fn leaf_from_iter<V: DagCbor>(
         &self,
         from: &mut iter::Peekable<impl Iterator<Item = (T::Key, V)>>,
         stream: &mut StreamBuilderState,
@@ -44,7 +42,7 @@ where
     /// Creates a leaf from a sequence that either contains all items from the sequence, or is full
     ///
     /// The result is the index of the leaf. The iterator will contain the elements that did not fit.
-    fn extend_leaf(
+    fn extend_leaf<V: DagCbor>(
         &self,
         compressed: &[u8],
         keys: Option<T::KeySeq>,
@@ -91,7 +89,7 @@ where
 
     /// given some children and some additional elements, creates a node with the given
     /// children and new children from `from` until it is full
-    pub(crate) fn extend_branch(
+    pub(crate) fn extend_branch<V: DagCbor>(
         &self,
         mut children: Vec<Index<T>>,
         level: u32,
@@ -155,7 +153,7 @@ where
     /// Given an iterator of values and a level, consume from the iterator until either
     /// the iterator is consumed or the node is "filled". At the end of this call, the
     /// iterator will contain the remaining elements that did not "fit".
-    fn fill_node(
+    fn fill_node<V: DagCbor>(
         &self,
         level: u32,
         from: &mut iter::Peekable<impl Iterator<Item = (T::Key, V)> + Send>,
@@ -208,7 +206,7 @@ where
     /// extends an existing node with some values
     ///
     /// The result will have the max level `level`. `from` will contain all elements that did not fit.
-    pub(crate) fn extend_above(
+    pub(crate) fn extend_above<V: DagCbor>(
         &self,
         node: Option<&Index<T>>,
         level: u32,
@@ -240,7 +238,7 @@ where
         Ok(node)
     }
 
-    pub(crate) fn extend_unpacked0<I>(
+    pub(crate) fn extend_unpacked0<I, V>(
         &self,
         index: Option<&Index<T>>,
         from: I,
@@ -249,6 +247,7 @@ where
     where
         I: IntoIterator<Item = (T::Key, V)>,
         I::IntoIter: Send,
+        V: DagCbor,
     {
         let mut from = from.into_iter().peekable();
         if from.peek().is_none() {
@@ -275,7 +274,7 @@ where
     /// extends an existing node with some values
     ///
     /// The result will have the same level as the input. `from` will contain all elements that did not fit.
-    fn extend0(
+    fn extend0<V: DagCbor>(
         &self,
         index: &Index<T>,
         from: &mut iter::Peekable<impl Iterator<Item = (T::Key, V)> + Send>,
@@ -293,16 +292,16 @@ where
         }
         let secrets = stream.secrets().clone();
         Ok(match self.load_node(&secrets, index) {
-            NodeInfo::Leaf(index, mut leaf) => {
+            NodeInfo::Leaf(index, leaf) => {
                 tracing::debug!("extending existing leaf");
                 let leaf = leaf.load()?;
                 let keys = index.keys.clone();
                 self.extend_leaf(leaf.as_ref().compressed(), Some(keys), from, stream)?
                     .into()
             }
-            NodeInfo::Branch(index, mut branch) => {
+            NodeInfo::Branch(index, branch) => {
                 tracing::debug!("extending existing branch");
-                let branch = branch.load()?;
+                let branch = branch.load_cached()?;
                 let mut children = branch.children.to_vec();
                 if let Some(last_child) = children.last_mut() {
                     *last_child =

--- a/banyan/src/store/mod.rs
+++ b/banyan/src/store/mod.rs
@@ -3,6 +3,7 @@ use anyhow::anyhow;
 use anyhow::Result;
 use core::hash::Hash;
 use fnv::FnvHashMap;
+use libipld::cbor::DagCbor;
 use parking_lot::Mutex;
 use std::{
     num::NonZeroUsize,
@@ -20,34 +21,22 @@ use crate::{
     TreeTypes,
 };
 
-pub trait BlockWriter<L>: Send + Sync {
+pub trait BanyanValue: DagCbor + Send + 'static {}
+
+impl<T: DagCbor + Send + Sync + 'static> BanyanValue for T {}
+
+pub trait BlockWriter<L>: Send + Sync + 'static {
     /// adds a block to a temporary staging area
     ///
     /// We might have to do this async at some point, but let's keep it sync for now.
     fn put(&self, data: Vec<u8>) -> Result<L>;
 }
 
-/// A block writer, we use dyn to avoid having just another type parameter
-pub type ArcBlockWriter<L> = Arc<dyn BlockWriter<L> + 'static>;
-
-impl<L> BlockWriter<L> for ArcBlockWriter<L> {
-    fn put(&self, data: Vec<u8>) -> Result<L> {
-        self.as_ref().put(data)
-    }
-}
-
-pub trait ReadOnlyStore<L> {
+pub trait ReadOnlyStore<L>: Clone + Send + Sync + 'static {
     fn get(&self, link: &L) -> Result<Box<[u8]>>;
 }
 
-pub type ArcReadOnlyStore<L> = Arc<dyn ReadOnlyStore<L> + Send + Sync + 'static>;
-
-impl<L> ReadOnlyStore<L> for ArcReadOnlyStore<L> {
-    fn get(&self, link: &L) -> Result<Box<[u8]>> {
-        self.as_ref().get(link)
-    }
-}
-
+#[derive(Clone)]
 pub struct MemReader<R, L> {
     inner: R,
     store: MemStore<L>,
@@ -140,7 +129,7 @@ impl<L: Eq + Hash + Copy> MemStore<L> {
     }
 }
 
-impl<L: Eq + Hash + Copy> ReadOnlyStore<L> for MemStore<L> {
+impl<L: Eq + Hash + Copy + Send + Sync + 'static> ReadOnlyStore<L> for MemStore<L> {
     fn get(&self, link: &L) -> anyhow::Result<Box<[u8]>> {
         if let Some(value) = self.get0(link) {
             Ok(value)

--- a/banyan/src/tree.rs
+++ b/banyan/src/tree.rs
@@ -5,7 +5,6 @@ use crate::{
         Config, FilteredChunk, Forest, ForestIter, IndexIter, Secrets, Transaction, TreeTypes,
     },
     store::BlockWriter,
-    util::BoxedIter,
 };
 use crate::{query::Query, store::ReadOnlyStore, util::IterExt, StreamBuilder, StreamBuilderState};
 use anyhow::Result;
@@ -164,8 +163,8 @@ impl<
         query: Q,
         index: Index<T>,
         mk_extra: &'static F,
-    ) -> BoxedIter<'static, Result<FilteredChunk<(u64, T::Key, V), E>>> {
-        ForestIter::new(self.clone(), secrets, query, index, mk_extra).boxed()
+    ) -> impl Iterator<Item = Result<FilteredChunk<(u64, T::Key, V), E>>> {
+        ForestIter::new(self.clone(), secrets, query, index, mk_extra)
     }
 
     pub(crate) fn traverse_rev0<
@@ -178,8 +177,8 @@ impl<
         query: Q,
         index: Index<T>,
         mk_extra: &'static F,
-    ) -> BoxedIter<'static, Result<FilteredChunk<(u64, T::Key, V), E>>> {
-        ForestIter::new_rev(self.clone(), secrets, query, index, mk_extra).boxed()
+    ) -> impl Iterator<Item = Result<FilteredChunk<(u64, T::Key, V), E>>> {
+        ForestIter::new_rev(self.clone(), secrets, query, index, mk_extra)
     }
 
     fn index_iter0<Q: Query<T> + Clone + Send + 'static>(
@@ -187,8 +186,8 @@ impl<
         secrets: Secrets,
         query: Q,
         index: Index<T>,
-    ) -> BoxedIter<'static, Result<Index<T>>> {
-        IndexIter::new(self.clone(), secrets, query, index).boxed()
+    ) -> impl Iterator<Item = Result<Index<T>>> {
+        IndexIter::new(self.clone(), secrets, query, index)
     }
 
     fn index_iter_rev0<Q: Query<T> + Clone + Send + 'static>(
@@ -196,8 +195,8 @@ impl<
         secrets: Secrets,
         query: Q,
         index: Index<T>,
-    ) -> BoxedIter<'static, Result<Index<T>>> {
-        IndexIter::new_rev(self.clone(), secrets, query, index).boxed()
+    ) -> impl Iterator<Item = Result<Index<T>>> {
+        IndexIter::new_rev(self.clone(), secrets, query, index)
     }
 
     pub(crate) fn dump_graph0<S>(
@@ -323,7 +322,6 @@ impl<
         match &tree.0 {
             Some((index, secrets, _)) => self
                 .index_iter0(secrets.clone(), query, index.clone())
-                .boxed()
                 .left_iter(),
             None => iter::empty().right_iter(),
         }
@@ -339,7 +337,6 @@ impl<
         match &tree.0 {
             Some((index, secrets, _)) => self
                 .index_iter_rev0(secrets.clone(), query, index.clone())
-                .boxed()
                 .left_iter(),
             None => iter::empty().right_iter(),
         }

--- a/banyan/src/tree.rs
+++ b/banyan/src/tree.rs
@@ -143,7 +143,7 @@ impl<
     pub fn dump_graph<S>(
         &self,
         tree: &Tree<T>,
-        f: impl Fn((usize, &NodeInfo2<T, V, R>)) -> S + Clone,
+        f: impl Fn((usize, &NodeInfo<T, V, R>)) -> S + Clone,
     ) -> Result<(GraphEdges, GraphNodes<S>)> {
         match &tree.0 {
             Some((index, secrets, _)) => self.dump_graph0(secrets, None, 0, index, f),
@@ -203,17 +203,17 @@ impl<
         parent_id: Option<usize>,
         next_id: usize,
         index: &Index<T>,
-        f: impl Fn((usize, &NodeInfo2<T, V, R>)) -> S + Clone,
+        f: impl Fn((usize, &NodeInfo<T, V, R>)) -> S + Clone,
     ) -> Result<(GraphEdges, GraphNodes<S>)> {
         let mut edges = vec![];
         let mut nodes: BTreeMap<usize, S> = Default::default();
 
-        let node = self.load_node_2(secrets, index);
+        let node = self.load_node(secrets, index);
         if let Some(p) = parent_id {
             edges.push((p, next_id));
         }
         nodes.insert(next_id, f((next_id, &node)));
-        if let NodeInfo2::Branch(_, mut branch) = node {
+        if let NodeInfo::Branch(_, mut branch) = node {
             let branch = branch.load()?;
             let mut cur = next_id;
             for x in branch.children.iter() {

--- a/banyan/src/tree.rs
+++ b/banyan/src/tree.rs
@@ -115,7 +115,7 @@ impl<
         config: Config,
         link: T::Link,
     ) -> Result<StreamBuilder<T>> {
-        let (index, byte_range) = self.load_branch_from_link(
+        let (index, byte_range) = self.create_index_from_link(
             &secrets,
             |items, level| config.branch_sealed(items, level),
             link,
@@ -126,7 +126,7 @@ impl<
 
     pub fn load_tree(&self, secrets: Secrets, link: T::Link) -> Result<Tree<T>> {
         // we pass in a predicate that makes the nodes sealed, since we don't care
-        let (index, byte_range) = self.load_branch_from_link(&secrets, |_, _| true, link)?;
+        let (index, byte_range) = self.create_index_from_link(&secrets, |_, _| true, link)?;
         // store the offset with the snapshot. Snapshots are immutable, so this won't change.
         Ok(Tree::new(index, secrets, byte_range.end))
     }

--- a/banyan/src/tree.rs
+++ b/banyan/src/tree.rs
@@ -2,22 +2,21 @@
 use super::index::*;
 use crate::{
     forest::{Config, FilteredChunk, Forest, IndexIter, Secrets, Transaction, TreeIter, TreeTypes},
-    store::BlockWriter,
+    store::{BanyanValue, BlockWriter},
 };
 use crate::{query::Query, store::ReadOnlyStore, util::IterExt, StreamBuilder, StreamBuilderState};
 use anyhow::Result;
 use core::fmt;
 use futures::prelude::*;
-use libipld::cbor::DagCbor;
-use std::{collections::BTreeMap, fmt::Debug, iter, usize};
+use std::{collections::BTreeMap, iter, marker::PhantomData, usize};
 use tracing::*;
 
 #[derive(Clone)]
-pub struct Tree<T: TreeTypes>(Option<(Index<T>, Secrets, u64)>);
+pub struct Tree<T: TreeTypes, V>(Option<(Index<T>, Secrets, u64)>, PhantomData<V>);
 
-impl<T: TreeTypes> Tree<T> {
+impl<T: TreeTypes, V> Tree<T, V> {
     pub(crate) fn new(root: Index<T>, secrets: Secrets, offset: u64) -> Self {
-        Self(Some((root, secrets, offset)))
+        Self(Some((root, secrets, offset)), PhantomData)
     }
 
     pub(crate) fn into_inner(self) -> Option<(Index<T>, Secrets, u64)> {
@@ -67,13 +66,13 @@ impl<T: TreeTypes> Tree<T> {
     }
 }
 
-impl<T: TreeTypes> Default for Tree<T> {
+impl<T: TreeTypes, V> Default for Tree<T, V> {
     fn default() -> Self {
-        Self(None)
+        Self(None, PhantomData)
     }
 }
 
-impl<T: TreeTypes> fmt::Debug for Tree<T> {
+impl<T: TreeTypes, V> fmt::Debug for Tree<T, V> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.0 {
             Some((root, ..)) => f
@@ -91,7 +90,7 @@ impl<T: TreeTypes> fmt::Debug for Tree<T> {
     }
 }
 
-impl<T: TreeTypes> fmt::Display for Tree<T> {
+impl<T: TreeTypes, V> fmt::Display for Tree<T, V> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.0 {
             Some((root, ..)) => write!(f, "{:?}", root.link(),),
@@ -103,18 +102,13 @@ impl<T: TreeTypes> fmt::Display for Tree<T> {
 pub type GraphEdges = Vec<(usize, usize)>;
 pub type GraphNodes<S> = BTreeMap<usize, S>;
 
-impl<
-        T: TreeTypes,
-        V: DagCbor + Clone + Send + Sync + Debug + 'static,
-        R: ReadOnlyStore<T::Link> + Clone + Send + Sync + 'static,
-    > Forest<T, V, R>
-{
-    pub fn load_stream_builder(
+impl<T: TreeTypes, R: ReadOnlyStore<T::Link>> Forest<T, R> {
+    pub fn load_stream_builder<V>(
         &self,
         secrets: Secrets,
         config: Config,
         link: T::Link,
-    ) -> Result<StreamBuilder<T>> {
+    ) -> Result<StreamBuilder<T, V>> {
         let (index, byte_range) = self.create_index_from_link(
             &secrets,
             |items, level| config.branch_sealed(items, level),
@@ -124,7 +118,7 @@ impl<
         Ok(StreamBuilder::new_from_index(Some(index), state))
     }
 
-    pub fn load_tree(&self, secrets: Secrets, link: T::Link) -> Result<Tree<T>> {
+    pub fn load_tree<V>(&self, secrets: Secrets, link: T::Link) -> Result<Tree<T, V>> {
         // we pass in a predicate that makes the nodes sealed, since we don't care
         let (index, byte_range) = self.create_index_from_link(&secrets, |_, _| true, link)?;
         // store the offset with the snapshot. Snapshots are immutable, so this won't change.
@@ -132,7 +126,7 @@ impl<
     }
 
     /// dumps the tree structure
-    pub fn dump(&self, tree: &Tree<T>) -> Result<()> {
+    pub fn dump<V>(&self, tree: &Tree<T, V>) -> Result<()> {
         match &tree.0 {
             Some((index, secrets, _)) => self.dump0(secrets, index, ""),
             None => Ok(()),
@@ -140,10 +134,10 @@ impl<
     }
 
     /// dumps the tree structure
-    pub fn dump_graph<S>(
+    pub fn dump_graph<S, V>(
         &self,
-        tree: &Tree<T>,
-        f: impl Fn((usize, &NodeInfo<T, V, R>)) -> S + Clone,
+        tree: &Tree<T, V>,
+        f: impl Fn((usize, &NodeInfo<T, R>)) -> S + Clone,
     ) -> Result<(GraphEdges, GraphNodes<S>)> {
         match &tree.0 {
             Some((index, secrets, _)) => self.dump_graph0(secrets, None, 0, index, f),
@@ -153,6 +147,7 @@ impl<
 
     pub(crate) fn traverse0<
         Q: Query<T> + Clone + Send + 'static,
+        V: BanyanValue,
         E: Send + 'static,
         F: Fn(IndexRef<T>) -> E + Send + Sync + 'static,
     >(
@@ -167,6 +162,7 @@ impl<
 
     pub(crate) fn traverse_rev0<
         Q: Query<T> + Clone + Send + 'static,
+        V: BanyanValue,
         E: Send + 'static,
         F: Fn(IndexRef<T>) -> E + Send + Sync + 'static,
     >(
@@ -203,7 +199,7 @@ impl<
         parent_id: Option<usize>,
         next_id: usize,
         index: &Index<T>,
-        f: impl Fn((usize, &NodeInfo<T, V, R>)) -> S + Clone,
+        f: impl Fn((usize, &NodeInfo<T, R>)) -> S + Clone,
     ) -> Result<(GraphEdges, GraphNodes<S>)> {
         let mut edges = vec![];
         let mut nodes: BTreeMap<usize, S> = Default::default();
@@ -213,8 +209,8 @@ impl<
             edges.push((p, next_id));
         }
         nodes.insert(next_id, f((next_id, &node)));
-        if let NodeInfo::Branch(_, mut branch) = node {
-            let branch = branch.load()?;
+        if let NodeInfo::Branch(_, branch) = node {
+            let branch = branch.load_cached()?;
             let mut cur = next_id;
             for x in branch.children.iter() {
                 let (mut e, mut n) =
@@ -229,7 +225,7 @@ impl<
     }
 
     /// sealed roots of the tree
-    pub fn roots(&self, tree: &StreamBuilder<T>) -> Result<Vec<Index<T>>> {
+    pub fn roots<V>(&self, tree: &StreamBuilder<T, V>) -> Result<Vec<Index<T>>> {
         match tree.index() {
             Some(index) => self.roots_impl(tree.state().secrets(), index),
             None => Ok(Vec::new()),
@@ -237,7 +233,7 @@ impl<
     }
 
     /// leftmost branches of the tree as separate trees
-    pub fn left_roots(&self, tree: &Tree<T>) -> Result<Vec<Tree<T>>> {
+    pub fn left_roots<V>(&self, tree: &Tree<T, V>) -> Result<Vec<Tree<T, V>>> {
         Ok(if let Some((index, secrets, _)) = &tree.0 {
             self.left_roots0(secrets, index)?
                 .into_iter()
@@ -249,10 +245,11 @@ impl<
     }
 
     /// leftmost branches of the tree as separate trees
-    fn left_roots0(&self, stream: &Secrets, index: &Index<T>) -> Result<Vec<Index<T>>> {
+    fn left_roots0(&self, secrets: &Secrets, index: &Index<T>) -> Result<Vec<Index<T>>> {
         let mut result = if let Index::Branch(branch) = index {
-            if let Some(branch) = self.load_branch_cached(stream, branch)? {
-                self.left_roots0(stream, branch.first_child())?
+            if let Some(link) = branch.link {
+                let branch = self.load_branch_cached_from_link(secrets, &link)?;
+                self.left_roots0(secrets, branch.first_child())?
             } else {
                 Vec::new()
             }
@@ -263,7 +260,7 @@ impl<
         Ok(result)
     }
 
-    pub fn check_invariants(&self, tree: &StreamBuilder<T>) -> Result<Vec<String>> {
+    pub fn check_invariants<V>(&self, tree: &StreamBuilder<T, V>) -> Result<Vec<String>> {
         let mut msgs = Vec::new();
         if let Some(root) = tree.index() {
             let mut level = i32::max_value();
@@ -278,7 +275,7 @@ impl<
         Ok(msgs)
     }
 
-    pub fn is_packed(&self, tree: &Tree<T>) -> Result<bool> {
+    pub fn is_packed<V>(&self, tree: &Tree<T, V>) -> Result<bool> {
         if let Some((root, secrets, _)) = &tree.0 {
             self.is_packed0(secrets, &root)
         } else {
@@ -286,7 +283,7 @@ impl<
         }
     }
 
-    pub fn assert_invariants(&self, tree: &StreamBuilder<T>) -> Result<()> {
+    pub fn assert_invariants<V>(&self, tree: &StreamBuilder<T, V>) -> Result<()> {
         let msgs = self.check_invariants(tree)?;
         if !msgs.is_empty() {
             let invariants = msgs.join(",");
@@ -298,9 +295,9 @@ impl<
         Ok(())
     }
 
-    pub fn stream_filtered(
+    pub fn stream_filtered<V: BanyanValue>(
         &self,
-        tree: &Tree<T>,
+        tree: &Tree<T, V>,
         query: impl Query<T> + Clone + 'static,
     ) -> impl Stream<Item = Result<(u64, T::Key, V)>> + 'static {
         match &tree.0 {
@@ -313,9 +310,9 @@ impl<
 
     /// Returns an iterator yielding all indexes that have values matching the
     /// provided query.
-    pub fn iter_index(
+    pub fn iter_index<V>(
         &self,
-        tree: &Tree<T>,
+        tree: &Tree<T, V>,
         query: impl Query<T> + Clone + 'static,
     ) -> impl Iterator<Item = Result<Index<T>>> + 'static {
         match &tree.0 {
@@ -328,9 +325,9 @@ impl<
 
     /// Returns an iterator yielding all indexes that have values matching the
     /// provided query in reverse order.
-    pub fn iter_index_reverse(
+    pub fn iter_index_reverse<V>(
         &self,
-        tree: &Tree<T>,
+        tree: &Tree<T, V>,
         query: impl Query<T> + Clone + 'static,
     ) -> impl Iterator<Item = Result<Index<T>>> + 'static {
         match &tree.0 {
@@ -341,9 +338,9 @@ impl<
         }
     }
 
-    pub fn iter_filtered(
+    pub fn iter_filtered<V: BanyanValue>(
         &self,
-        tree: &Tree<T>,
+        tree: &Tree<T, V>,
         query: impl Query<T> + Clone + 'static,
     ) -> impl Iterator<Item = Result<(u64, T::Key, V)>> + 'static {
         match &tree.0 {
@@ -354,9 +351,9 @@ impl<
         }
     }
 
-    pub fn iter_filtered_reverse(
+    pub fn iter_filtered_reverse<V: BanyanValue>(
         &self,
-        tree: &Tree<T>,
+        tree: &Tree<T, V>,
         query: impl Query<T> + Clone + 'static,
     ) -> impl Iterator<Item = Result<(u64, T::Key, V)>> + 'static {
         match &tree.0 {
@@ -367,9 +364,9 @@ impl<
         }
     }
 
-    pub fn iter_from(
+    pub fn iter_from<V: BanyanValue>(
         &self,
-        tree: &Tree<T>,
+        tree: &Tree<T, V>,
     ) -> impl Iterator<Item = Result<(u64, T::Key, V)>> + 'static {
         match &tree.0 {
             Some((index, secrets, _)) => self
@@ -379,14 +376,15 @@ impl<
         }
     }
 
-    pub fn iter_filtered_chunked<Q, E, F>(
+    pub fn iter_filtered_chunked<Q, V, E, F>(
         &self,
-        tree: &Tree<T>,
+        tree: &Tree<T, V>,
         query: Q,
         mk_extra: &'static F,
     ) -> impl Iterator<Item = Result<FilteredChunk<(u64, T::Key, V), E>>> + 'static
     where
         Q: Query<T> + Send + Clone + 'static,
+        V: BanyanValue,
         E: Send + 'static,
         F: Fn(IndexRef<T>) -> E + Send + Sync + 'static,
     {
@@ -398,14 +396,15 @@ impl<
         }
     }
 
-    pub fn iter_filtered_chunked_reverse<Q, E, F>(
+    pub fn iter_filtered_chunked_reverse<Q, V, E, F>(
         &self,
-        tree: &Tree<T>,
+        tree: &Tree<T, V>,
         query: Q,
         mk_extra: &'static F,
     ) -> impl Iterator<Item = Result<FilteredChunk<(u64, T::Key, V), E>>> + 'static
     where
         Q: Query<T> + Send + Clone + 'static,
+        V: BanyanValue,
         E: Send + 'static,
         F: Fn(IndexRef<T>) -> E + Send + Sync + 'static,
     {
@@ -417,14 +416,15 @@ impl<
         }
     }
 
-    pub fn stream_filtered_chunked<Q, E, F>(
+    pub fn stream_filtered_chunked<Q, V, E, F>(
         &self,
-        tree: &Tree<T>,
+        tree: &Tree<T, V>,
         query: Q,
         mk_extra: &'static F,
     ) -> impl Stream<Item = Result<FilteredChunk<(u64, T::Key, V), E>>> + 'static
     where
         Q: Query<T> + Send + Clone + 'static,
+        V: BanyanValue,
         E: Send + 'static,
         F: Fn(IndexRef<T>) -> E + Send + Sync + 'static,
     {
@@ -436,14 +436,15 @@ impl<
         }
     }
 
-    pub fn stream_filtered_chunked_reverse<Q, E, F>(
+    pub fn stream_filtered_chunked_reverse<Q, V, E, F>(
         &self,
-        tree: &Tree<T>,
+        tree: &Tree<T, V>,
         query: Q,
         mk_extra: &'static F,
     ) -> impl Stream<Item = Result<FilteredChunk<(u64, T::Key, V), E>>> + 'static
     where
         Q: Query<T> + Send + Clone + 'static,
+        V: BanyanValue,
         E: Send + 'static,
         F: Fn(IndexRef<T>) -> E + Send + Sync + 'static,
     {
@@ -460,7 +461,11 @@ impl<
     /// returns Ok(None) when offset is larger than count, or when hitting a purged
     /// part of the tree. Returns an error when part of the tree should be there, but could
     /// not be read.
-    pub fn get(&self, tree: &Tree<T>, offset: u64) -> Result<Option<(T::Key, V)>> {
+    pub fn get<V: BanyanValue>(
+        &self,
+        tree: &Tree<T, V>,
+        offset: u64,
+    ) -> Result<Option<(T::Key, V)>> {
         Ok(match &tree.0 {
             Some((index, secrets, _)) => self.get0(secrets, index, offset)?,
             None => None,
@@ -469,13 +474,17 @@ impl<
 
     /// Collects all elements from a stream. Might produce an OOM for large streams.
     #[allow(clippy::type_complexity)]
-    pub fn collect(&self, tree: &Tree<T>) -> Result<Vec<Option<(T::Key, V)>>> {
+    pub fn collect<V: BanyanValue>(&self, tree: &Tree<T, V>) -> Result<Vec<Option<(T::Key, V)>>> {
         self.collect_from(tree, 0)
     }
 
     /// Collects all elements from the given offset. Might produce an OOM for large streams.
     #[allow(clippy::type_complexity)]
-    pub fn collect_from(&self, tree: &Tree<T>, offset: u64) -> Result<Vec<Option<(T::Key, V)>>> {
+    pub fn collect_from<V: BanyanValue>(
+        &self,
+        tree: &Tree<T, V>,
+        offset: u64,
+    ) -> Result<Vec<Option<(T::Key, V)>>> {
         let mut res = Vec::new();
         if let Some((index, secrets, _)) = &tree.0 {
             self.collect0(secrets, index, offset, &mut res)?;
@@ -484,17 +493,11 @@ impl<
     }
 }
 
-impl<
-        T: TreeTypes,
-        V: DagCbor + Clone + Send + Sync + Debug + 'static,
-        R: ReadOnlyStore<T::Link> + Clone + Send + Sync + 'static,
-        W: BlockWriter<T::Link> + 'static,
-    > Transaction<T, V, R, W>
-{
-    pub(crate) fn tree_from_roots(
+impl<T: TreeTypes, R: ReadOnlyStore<T::Link>, W: BlockWriter<T::Link>> Transaction<T, R, W> {
+    pub(crate) fn tree_from_roots<V>(
         &self,
         mut roots: Vec<Index<T>>,
-        stream: &mut StreamBuilder<T>,
+        stream: &mut StreamBuilder<T, V>,
     ) -> Result<()> {
         assert!(roots.iter().all(|x| x.sealed()));
         assert!(is_sorted(roots.iter().map(|x| x.level()).rev()));
@@ -512,7 +515,7 @@ impl<
     /// Likewise, sealed subtrees or leafs will be reused if possible.
     ///
     /// ![packing illustration](https://ipfs.io/ipfs/QmaEDTjHSdCKyGQ3cFMCf73kE67NvffLA5agquLW5qSEVn/packing.jpg)
-    pub fn pack(&self, tree: &mut StreamBuilder<T>) -> Result<()> {
+    pub fn pack<V: BanyanValue>(&self, tree: &mut StreamBuilder<T, V>) -> Result<()> {
         let initial = tree.snapshot();
         let roots = self.roots(tree)?;
         self.tree_from_roots(roots, tree)?;
@@ -526,17 +529,23 @@ impl<
     }
 
     /// append a single element. This is just a shortcut for extend.
-    pub fn push(&mut self, tree: &mut StreamBuilder<T>, key: T::Key, value: V) -> Result<()> {
+    pub fn push<V: BanyanValue>(
+        &mut self,
+        tree: &mut StreamBuilder<T, V>,
+        key: T::Key,
+        value: V,
+    ) -> Result<()> {
         self.extend(tree, Some((key, value)))
     }
 
     /// extend the node with the given iterator of key/value pairs
     ///
     /// ![extend illustration](https://ipfs.io/ipfs/QmaEDTjHSdCKyGQ3cFMCf73kE67NvffLA5agquLW5qSEVn/extend.jpg)
-    pub fn extend<I>(&self, tree: &mut StreamBuilder<T>, from: I) -> Result<()>
+    pub fn extend<I, V>(&self, tree: &mut StreamBuilder<T, V>, from: I) -> Result<()>
     where
         I: IntoIterator<Item = (T::Key, V)>,
         I::IntoIter: Send,
+        V: BanyanValue,
     {
         let mut from = from.into_iter().peekable();
         if from.peek().is_none() {
@@ -563,10 +572,11 @@ impl<
     /// To pack a tree, use the pack method.
     ///
     /// ![extend_unpacked illustration](https://ipfs.io/ipfs/QmaEDTjHSdCKyGQ3cFMCf73kE67NvffLA5agquLW5qSEVn/extend_unpacked.jpg)
-    pub fn extend_unpacked<I>(&self, tree: &mut StreamBuilder<T>, from: I) -> Result<()>
+    pub fn extend_unpacked<I, V>(&self, tree: &mut StreamBuilder<T, V>, from: I) -> Result<()>
     where
         I: IntoIterator<Item = (T::Key, V)>,
         I::IntoIter: Send,
+        V: BanyanValue,
     {
         let index = tree.as_index_ref().cloned();
         let index = self.extend_unpacked0(index.as_ref(), from, tree.state_mut())?;
@@ -584,9 +594,9 @@ impl<
     ///
     /// note that offsets will not be affected by this. Also, unsealed nodes will not be forgotten
     /// even if they do not match the query.
-    pub fn retain<'a, Q: Query<T> + Send + Sync>(
+    pub fn retain<'a, Q: Query<T> + Send + Sync, V>(
         &'a self,
-        tree: &mut StreamBuilder<T>,
+        tree: &mut StreamBuilder<T, V>,
         query: &'a Q,
     ) -> Result<()> {
         let index = tree.index().cloned();
@@ -605,7 +615,7 @@ impl<
     /// Note that this is an emergency measure to recover data if the tree is not completely
     /// available. It might result in a degenerate tree that can no longer be safely added to,
     /// especially if there are repaired blocks in the non-packed part.
-    pub fn repair(&self, tree: &mut StreamBuilder<T>) -> Result<Vec<String>> {
+    pub fn repair<V>(&self, tree: &mut StreamBuilder<T, V>) -> Result<Vec<String>> {
         let mut report = Vec::new();
         let index = tree.index().cloned();
         if let Some(index) = index {

--- a/banyan/src/tree.rs
+++ b/banyan/src/tree.rs
@@ -146,7 +146,7 @@ impl<T: TreeTypes, R: ReadOnlyStore<T::Link>> Forest<T, R> {
     }
 
     pub(crate) fn traverse0<
-        Q: Query<T> + Clone + Send + 'static,
+        Q: Query<T>,
         V: BanyanValue,
         E: Send + 'static,
         F: Fn(IndexRef<T>) -> E + Send + Sync + 'static,
@@ -161,7 +161,7 @@ impl<T: TreeTypes, R: ReadOnlyStore<T::Link>> Forest<T, R> {
     }
 
     pub(crate) fn traverse_rev0<
-        Q: Query<T> + Clone + Send + 'static,
+        Q: Query<T>,
         V: BanyanValue,
         E: Send + 'static,
         F: Fn(IndexRef<T>) -> E + Send + Sync + 'static,
@@ -383,7 +383,7 @@ impl<T: TreeTypes, R: ReadOnlyStore<T::Link>> Forest<T, R> {
         mk_extra: &'static F,
     ) -> impl Iterator<Item = Result<FilteredChunk<(u64, T::Key, V), E>>> + 'static
     where
-        Q: Query<T> + Send + Clone + 'static,
+        Q: Query<T>,
         V: BanyanValue,
         E: Send + 'static,
         F: Fn(IndexRef<T>) -> E + Send + Sync + 'static,
@@ -403,7 +403,7 @@ impl<T: TreeTypes, R: ReadOnlyStore<T::Link>> Forest<T, R> {
         mk_extra: &'static F,
     ) -> impl Iterator<Item = Result<FilteredChunk<(u64, T::Key, V), E>>> + 'static
     where
-        Q: Query<T> + Send + Clone + 'static,
+        Q: Query<T>,
         V: BanyanValue,
         E: Send + 'static,
         F: Fn(IndexRef<T>) -> E + Send + Sync + 'static,
@@ -423,7 +423,7 @@ impl<T: TreeTypes, R: ReadOnlyStore<T::Link>> Forest<T, R> {
         mk_extra: &'static F,
     ) -> impl Stream<Item = Result<FilteredChunk<(u64, T::Key, V), E>>> + 'static
     where
-        Q: Query<T> + Send + Clone + 'static,
+        Q: Query<T>,
         V: BanyanValue,
         E: Send + 'static,
         F: Fn(IndexRef<T>) -> E + Send + Sync + 'static,
@@ -443,7 +443,7 @@ impl<T: TreeTypes, R: ReadOnlyStore<T::Link>> Forest<T, R> {
         mk_extra: &'static F,
     ) -> impl Stream<Item = Result<FilteredChunk<(u64, T::Key, V), E>>> + 'static
     where
-        Q: Query<T> + Send + Clone + 'static,
+        Q: Query<T>,
         V: BanyanValue,
         E: Send + 'static,
         F: Fn(IndexRef<T>) -> E + Send + Sync + 'static,

--- a/banyan/src/tree.rs
+++ b/banyan/src/tree.rs
@@ -164,7 +164,7 @@ impl<
         query: Q,
         index: Index<T>,
         mk_extra: &'static F,
-    ) -> BoxedIter<'static, Result<FilteredChunk<T, V, E>>> {
+    ) -> BoxedIter<'static, Result<FilteredChunk<(u64, T::Key, V), E>>> {
         ForestIter::new(self.clone(), secrets, query, index, mk_extra).boxed()
     }
 
@@ -178,7 +178,7 @@ impl<
         query: Q,
         index: Index<T>,
         mk_extra: &'static F,
-    ) -> BoxedIter<'static, Result<FilteredChunk<T, V, E>>> {
+    ) -> BoxedIter<'static, Result<FilteredChunk<(u64, T::Key, V), E>>> {
         ForestIter::new_rev(self.clone(), secrets, query, index, mk_extra).boxed()
     }
 
@@ -388,7 +388,7 @@ impl<
         tree: &Tree<T>,
         query: Q,
         mk_extra: &'static F,
-    ) -> impl Iterator<Item = Result<FilteredChunk<T, V, E>>> + 'static
+    ) -> impl Iterator<Item = Result<FilteredChunk<(u64, T::Key, V), E>>> + 'static
     where
         Q: Query<T> + Send + Clone + 'static,
         E: Send + 'static,
@@ -407,7 +407,7 @@ impl<
         tree: &Tree<T>,
         query: Q,
         mk_extra: &'static F,
-    ) -> impl Iterator<Item = Result<FilteredChunk<T, V, E>>> + 'static
+    ) -> impl Iterator<Item = Result<FilteredChunk<(u64, T::Key, V), E>>> + 'static
     where
         Q: Query<T> + Send + Clone + 'static,
         E: Send + 'static,
@@ -426,7 +426,7 @@ impl<
         tree: &Tree<T>,
         query: Q,
         mk_extra: &'static F,
-    ) -> impl Stream<Item = Result<FilteredChunk<T, V, E>>> + 'static
+    ) -> impl Stream<Item = Result<FilteredChunk<(u64, T::Key, V), E>>> + 'static
     where
         Q: Query<T> + Send + Clone + 'static,
         E: Send + 'static,
@@ -445,7 +445,7 @@ impl<
         tree: &Tree<T>,
         query: Q,
         mk_extra: &'static F,
-    ) -> impl Stream<Item = Result<FilteredChunk<T, V, E>>> + 'static
+    ) -> impl Stream<Item = Result<FilteredChunk<(u64, T::Key, V), E>>> + 'static
     where
         Q: Query<T> + Send + Clone + 'static,
         E: Send + 'static,

--- a/banyan/src/tree.rs
+++ b/banyan/src/tree.rs
@@ -1,9 +1,7 @@
 //! creation and traversal of banyan trees
 use super::index::*;
 use crate::{
-    forest::{
-        Config, FilteredChunk, Forest, ForestIter, IndexIter, Secrets, Transaction, TreeTypes,
-    },
+    forest::{Config, FilteredChunk, Forest, IndexIter, Secrets, Transaction, TreeIter, TreeTypes},
     store::BlockWriter,
 };
 use crate::{query::Query, store::ReadOnlyStore, util::IterExt, StreamBuilder, StreamBuilderState};
@@ -164,7 +162,7 @@ impl<
         index: Index<T>,
         mk_extra: &'static F,
     ) -> impl Iterator<Item = Result<FilteredChunk<(u64, T::Key, V), E>>> {
-        ForestIter::new(self.clone(), secrets, query, index, mk_extra)
+        TreeIter::new(self.clone(), secrets, query, index, mk_extra)
     }
 
     pub(crate) fn traverse_rev0<
@@ -178,7 +176,7 @@ impl<
         index: Index<T>,
         mk_extra: &'static F,
     ) -> impl Iterator<Item = Result<FilteredChunk<(u64, T::Key, V), E>>> {
-        ForestIter::new_rev(self.clone(), secrets, query, index, mk_extra)
+        TreeIter::new_rev(self.clone(), secrets, query, index, mk_extra)
     }
 
     fn index_iter0<Q: Query<T> + Clone + Send + 'static>(

--- a/banyan/src/tree.rs
+++ b/banyan/src/tree.rs
@@ -143,7 +143,7 @@ impl<
     pub fn dump_graph<S>(
         &self,
         tree: &Tree<T>,
-        f: impl Fn((usize, &NodeInfo<T>)) -> S + Clone,
+        f: impl Fn((usize, &NodeInfo2<T, V, R>)) -> S + Clone,
     ) -> Result<(GraphEdges, GraphNodes<S>)> {
         match &tree.0 {
             Some((index, secrets, _)) => self.dump_graph0(secrets, None, 0, index, f),
@@ -203,17 +203,18 @@ impl<
         parent_id: Option<usize>,
         next_id: usize,
         index: &Index<T>,
-        f: impl Fn((usize, &NodeInfo<T>)) -> S + Clone,
+        f: impl Fn((usize, &NodeInfo2<T, V, R>)) -> S + Clone,
     ) -> Result<(GraphEdges, GraphNodes<S>)> {
         let mut edges = vec![];
         let mut nodes: BTreeMap<usize, S> = Default::default();
 
-        let node = self.load_node(secrets, index)?;
+        let node = self.load_node_2(secrets, index);
         if let Some(p) = parent_id {
             edges.push((p, next_id));
         }
         nodes.insert(next_id, f((next_id, &node)));
-        if let NodeInfo::Branch(_, branch) = node {
+        if let NodeInfo2::Branch(_, mut branch) = node {
+            let branch = branch.load()?;
             let mut cur = next_id;
             for x in branch.children.iter() {
                 let (mut e, mut n) =

--- a/banyan/src/util.rs
+++ b/banyan/src/util.rs
@@ -106,6 +106,7 @@ where
 {
 }
 
+#[allow(dead_code)]
 pub(crate) type BoxedIter<'a, T> = Box<dyn Iterator<Item = T> + Send + 'a>;
 
 /// Like the one from itertools, but more convenient

--- a/banyan/tests/link_scraping.rs
+++ b/banyan/tests/link_scraping.rs
@@ -12,7 +12,7 @@ use std::str::FromStr;
 
 mod common;
 
-type Txn = Transaction<TT, Payload, MemStore<Sha256Digest>, MemStore<Sha256Digest>>;
+type Txn = Transaction<TT, MemStore<Sha256Digest>, MemStore<Sha256Digest>>;
 
 impl Arbitrary for Key {
     fn arbitrary(g: &mut Gen) -> Self {
@@ -66,14 +66,14 @@ fn txn(store: MemStore<Sha256Digest>) -> Txn {
     Txn::new(Forest::new(store.clone(), branch_cache), store)
 }
 
-fn create_test_tree<I>(xs: I) -> anyhow::Result<(Tree<TT>, Txn)>
+fn create_test_tree<I>(xs: I) -> anyhow::Result<(Tree<TT, Payload>, Txn)>
 where
     I: IntoIterator<Item = (Key, Payload)>,
     I::IntoIter: Send,
 {
     let store = MemStore::new(usize::max_value(), Sha256Digest::digest);
     let forest = txn(store);
-    let mut tree = StreamBuilder::<TT>::debug();
+    let mut tree = StreamBuilder::<TT, Payload>::debug();
     forest.extend(&mut tree, xs)?;
     forest.assert_invariants(&tree)?;
     Ok((tree.snapshot(), forest))


### PR DESCRIPTION
Change NodeInfo so that loading the branch / leaf is lazy. This hopefully combines the convenience of NodeInfo with being able to not load some data if not needed.

Also, move the V type parameter from Forest to Tree / Builder, and prettify all the type constraints.

Will make a quick test how much work it is to adapt cosmos. If it is much, I will release this as 0.14, if not as 0.13.