### PR TITLE
Do all tests with both packed and unpacked test trees

### DIFF
--- a/banyan/tests/build_check.rs
+++ b/banyan/tests/build_check.rs
@@ -4,7 +4,7 @@ use banyan::{
     store::{BranchCache, MemStore},
     Config, Forest, Secrets, StreamBuilder, Tree,
 };
-use common::{create_test_tree, txn, IterExt, Key, KeySeq, Sha256Digest, TT};
+use common::{create_test_tree, txn, IterExt, Key, KeySeq, Sha256Digest, TestTree, TT};
 use futures::prelude::*;
 use libipld::{cbor::DagCborCodec, codec::Codec, Cid};
 use quickcheck::TestResult;
@@ -16,8 +16,8 @@ use crate::common::no_offset_overlap;
 mod common;
 
 #[quickcheck]
-fn build_stream(xs: Vec<(Key, u64)>) -> anyhow::Result<bool> {
-    let (tree, txn) = create_test_tree(xs.clone())?;
+fn build_stream(t: TestTree) -> anyhow::Result<bool> {
+    let (tree, txn, xs) = t.tree()?;
     let actual = txn
         .iter_filtered(&tree, AllQuery)
         .map(|res| res.map(|(_, k, v)| (k, v)))
@@ -26,8 +26,8 @@ fn build_stream(xs: Vec<(Key, u64)>) -> anyhow::Result<bool> {
 }
 
 /// checks that stream_filtered returns the same elements as filtering each element manually
-fn compare_filtered(xs: Vec<(Key, u64)>, range: Range<u64>) -> anyhow::Result<bool> {
-    let (tree, txn) = create_test_tree(xs.clone())?;
+fn compare_filtered(t: TestTree, range: Range<u64>) -> anyhow::Result<bool> {
+    let (tree, txn, xs) = t.tree()?;
     let actual = txn
         .iter_filtered(&tree, OffsetRangeQuery::from(range.clone()))
         .collect::<anyhow::Result<Vec<_>>>()?;
@@ -42,8 +42,8 @@ fn compare_filtered(xs: Vec<(Key, u64)>, range: Range<u64>) -> anyhow::Result<bo
 }
 
 /// checks that stream_filtered_chunked returns the same elements as filtering each element manually
-fn compare_filtered_chunked(xs: Vec<(Key, u64)>, range: Range<u64>) -> anyhow::Result<bool> {
-    let (tree, txn) = create_test_tree(xs.clone())?;
+fn compare_filtered_chunked(t: TestTree, range: Range<u64>) -> anyhow::Result<bool> {
+    let (tree, txn, xs) = t.tree()?;
     let actual = txn
         .iter_filtered_chunked(&tree, OffsetRangeQuery::from(range.clone()), &|_| ())
         .map(|chunk_result| match chunk_result {
@@ -62,11 +62,8 @@ fn compare_filtered_chunked(xs: Vec<(Key, u64)>, range: Range<u64>) -> anyhow::R
     Ok(actual == expected)
 }
 /// checks that stream_filtered_chunked returns the same elements as stream_filtered_chunked_reverse
-fn compare_filtered_chunked_with_reverse(
-    xs: Vec<(Key, u64)>,
-    range: Range<u64>,
-) -> anyhow::Result<bool> {
-    let (tree, txn) = create_test_tree(xs.clone())?;
+fn compare_filtered_chunked_with_reverse(t: TestTree, range: Range<u64>) -> anyhow::Result<bool> {
+    let (tree, txn, xs) = t.tree()?;
     let mut reverse = txn
         .iter_filtered_chunked_reverse(&tree, OffsetRangeQuery::from(range.clone()), &|_| ())
         .map(|chunk_result| match chunk_result {
@@ -96,11 +93,8 @@ fn compare_filtered_chunked_with_reverse(
 }
 
 /// checks that stream_filtered_chunked returns the same elements as filtering each element manually
-fn compare_filtered_chunked_reverse(
-    xs: Vec<(Key, u64)>,
-    range: Range<u64>,
-) -> anyhow::Result<bool> {
-    let (tree, txn) = create_test_tree(xs.clone())?;
+fn compare_filtered_chunked_reverse(t: TestTree, range: Range<u64>) -> anyhow::Result<bool> {
+    let (tree, txn, xs) = t.tree()?;
     let actual = txn
         .iter_filtered_chunked_reverse(&tree, OffsetRangeQuery::from(range.clone()), &|_| ())
         .map(|chunk_result| match chunk_result {
@@ -124,8 +118,8 @@ fn compare_filtered_chunked_reverse(
 }
 
 /// checks that stream_filtered_chunked returns the same elements as filtering each element manually
-fn filtered_chunked_no_holes(xs: Vec<(Key, u64)>, range: Range<u64>) -> anyhow::Result<bool> {
-    let (tree, txn) = create_test_tree(xs.clone())?;
+fn filtered_chunked_no_holes(t: TestTree, range: Range<u64>) -> anyhow::Result<bool> {
+    let (tree, txn, xs) = t.tree()?;
     let chunks = txn
         .iter_filtered_chunked(&tree, OffsetRangeQuery::from(range), &|_| ())
         .collect::<anyhow::Result<Vec<_>>>()?;
@@ -163,42 +157,36 @@ fn build_iter_index(xs: Vec<(Key, u64)>) -> anyhow::Result<bool> {
 }
 
 #[quickcheck]
-fn build_stream_filtered(xs: Vec<(Key, u64)>, range: Range<u64>) -> anyhow::Result<bool> {
-    compare_filtered(xs, range)
+fn build_stream_filtered(t: TestTree, range: Range<u64>) -> anyhow::Result<bool> {
+    compare_filtered(t, range)
 }
 
 #[quickcheck]
-fn build_stream_filtered_chunked(xs: Vec<(Key, u64)>, range: Range<u64>) -> anyhow::Result<bool> {
-    compare_filtered_chunked(xs, range)
+fn build_stream_filtered_chunked(t: TestTree, range: Range<u64>) -> anyhow::Result<bool> {
+    compare_filtered_chunked(t, range)
 }
 
 #[quickcheck]
 fn build_stream_filtered_chunked_forward_and_reverse(
-    xs: Vec<(Key, u64)>,
+    t: TestTree,
     range: Range<u64>,
 ) -> anyhow::Result<bool> {
-    compare_filtered_chunked_with_reverse(xs, range)
+    compare_filtered_chunked_with_reverse(t, range)
 }
 
 #[quickcheck]
-fn build_stream_filtered_chunked_reverse(
-    xs: Vec<(Key, u64)>,
-    range: Range<u64>,
-) -> anyhow::Result<bool> {
-    compare_filtered_chunked_reverse(xs, range)
+fn build_stream_filtered_chunked_reverse(t: TestTree, range: Range<u64>) -> anyhow::Result<bool> {
+    compare_filtered_chunked_reverse(t, range)
 }
 
 #[quickcheck]
-fn build_stream_filtered_chunked_no_holes(
-    xs: Vec<(Key, u64)>,
-    range: Range<u64>,
-) -> anyhow::Result<bool> {
-    filtered_chunked_no_holes(xs, range)
+fn build_stream_filtered_chunked_no_holes(t: TestTree, range: Range<u64>) -> anyhow::Result<bool> {
+    filtered_chunked_no_holes(t, range)
 }
 
 #[quickcheck]
-fn build_get(xs: Vec<(Key, u64)>) -> anyhow::Result<bool> {
-    let (tree, txn) = create_test_tree(xs.clone())?;
+fn build_get(t: TestTree) -> anyhow::Result<bool> {
+    let (tree, txn, xs) = t.tree()?;
     let mut actual = Vec::new();
     for i in 0..xs.len() as u64 {
         actual.push(txn.get(&tree, i)?.unwrap());
@@ -250,42 +238,30 @@ fn build_pack_1() {
     assert!(do_build_pack(xss).unwrap());
 }
 
-fn do_retain(xss: Vec<Vec<(Key, u64)>>) -> anyhow::Result<bool> {
-    let store = MemStore::new(usize::max_value(), Sha256Digest::digest);
-    let forest = txn(store, 1000);
-    let mut builder = StreamBuilder::<TT, u64>::debug();
-    // flattened xss for reference
-    let xs = xss.iter().cloned().flatten().collect::<Vec<_>>();
-    // build complex unbalanced tree
-    for xs in xss.iter() {
-        forest.extend_unpacked(&mut builder, xs.clone()).unwrap();
-    }
+fn do_retain(t: TestTree) -> anyhow::Result<bool> {
+    let (mut builder, txn, xs) = t.builder()?;
     let tree0 = builder.snapshot();
-    forest.retain(&mut builder, &OffsetRangeQuery::from(xs.len() as u64..))?;
+    txn.retain(&mut builder, &OffsetRangeQuery::from(xs.len() as u64..))?;
     let tree1 = builder.snapshot();
-    forest.assert_invariants(&builder)?;
-    forest.pack(&mut builder)?;
+    txn.assert_invariants(&builder)?;
+    txn.pack(&mut builder)?;
     let tree2 = builder.snapshot();
-    forest.retain(&mut builder, &OffsetRangeQuery::from(xs.len() as u64..))?;
-    forest.assert_invariants(&builder)?;
+    txn.retain(&mut builder, &OffsetRangeQuery::from(xs.len() as u64..))?;
+    txn.assert_invariants(&builder)?;
     let tree3 = builder.snapshot();
-    let offsets_ok = no_offset_overlap(&forest, &[tree0, tree1, tree2, tree3])?;
+    let offsets_ok = no_offset_overlap(&txn, &[tree0, tree1, tree2, tree3])?;
     Ok(offsets_ok)
 }
 
 #[quickcheck]
-fn retain(xss: Vec<Vec<(Key, u64)>>) -> anyhow::Result<bool> {
-    do_retain(xss)
+fn retain(t: TestTree) -> anyhow::Result<bool> {
+    do_retain(t)
 }
 
 #[quickcheck]
-fn iter_from_should_return_all_items(xs: Vec<(Key, u64)>) -> anyhow::Result<bool> {
-    let store = MemStore::new(usize::max_value(), Sha256Digest::digest);
-    let forest = txn(store, 1000);
-    let mut builder = StreamBuilder::<TT, u64>::debug();
-    forest.extend(&mut builder, xs.clone().into_iter())?;
-    forest.assert_invariants(&builder)?;
-    let actual = forest
+fn iter_from_should_return_all_items(t: TestTree) -> anyhow::Result<bool> {
+    let (builder, txn, xs) = t.builder()?;
+    let actual = txn
         .iter_from(&builder.snapshot())
         .collect::<anyhow::Result<Vec<_>>>()?;
     let expected = xs
@@ -303,7 +279,7 @@ fn iter_from_should_return_all_items(xs: Vec<(Key, u64)>) -> anyhow::Result<bool
 #[test]
 fn filter_test_simple() -> anyhow::Result<()> {
     let _ = env_logger::builder().is_test(true).try_init();
-    let ok = compare_filtered(vec![(Key(1), 1), (Key(2), 2)], 0..1)?;
+    let ok = compare_filtered(TestTree::packed(vec![(Key(1), 1), (Key(2), 2)]), 0..1)?;
     assert!(ok);
     Ok(())
 }
@@ -352,16 +328,13 @@ async fn stream_test_simple() -> anyhow::Result<()> {
 
 #[quickcheck_async::tokio]
 async fn stream_trees_chunked_should_honour_an_inclusive_upper_bound(
-    xs: Vec<(Key, u64)>,
+    t: TestTree,
 ) -> anyhow::Result<TestResult> {
+    let (builder, forest, xs) = t.builder()?;
     let len = xs.len() as u64;
     if len == 0 {
         return Ok(TestResult::discard());
     }
-    let store = MemStore::new(usize::max_value(), Sha256Digest::digest);
-    let forest = txn(store, 1000);
-    let mut builder = StreamBuilder::<TT, u64>::debug();
-    forest.extend_unpacked(&mut builder, xs.clone().into_iter())?;
     let trees = stream::once(async move { builder.snapshot() }).chain(stream::pending());
 
     let actual = forest
@@ -611,7 +584,7 @@ A7                                      # map(7)
 #[test]
 fn retain1() -> anyhow::Result<()> {
     let xs = (0..10).map(|i| (Key(i), i)).collect::<Vec<_>>();
-    let ok = do_retain(vec![xs])?;
+    let ok = do_retain(TestTree::packed(xs))?;
     assert!(ok);
     Ok(())
 }
@@ -763,7 +736,7 @@ fn retain2() -> anyhow::Result<()> {
             (Key(39), 0),
         ],
     ];
-    let ok = do_retain(xs)?;
+    let ok = do_retain(TestTree::unpacked(xs))?;
     assert!(ok);
     Ok(())
 }

--- a/banyan/tests/common.rs
+++ b/banyan/tests/common.rs
@@ -93,19 +93,6 @@ pub fn txn(store: MemStore<Sha256Digest>, cache_cap: usize) -> Txn {
     Txn::new(Forest::new(store.clone(), branch_cache), store)
 }
 
-pub fn create_test_tree<I>(xs: I) -> anyhow::Result<(Tree<TT, u64>, Txn)>
-where
-    I: IntoIterator<Item = (Key, u64)>,
-    I::IntoIter: Send,
-{
-    let store = MemStore::new(usize::max_value(), Sha256Digest::digest);
-    let forest = txn(store, 1 << 20);
-    let mut builder = StreamBuilder::<TT, u64>::debug();
-    forest.extend(&mut builder, xs)?;
-    forest.assert_invariants(&builder)?;
-    Ok((builder.snapshot(), forest))
-}
-
 /// A recipe for a tree, which will either be packed or unpacked
 #[derive(Debug, Clone)]
 pub enum TestTree {

--- a/banyan/tests/common.rs
+++ b/banyan/tests/common.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::upper_case_acronyms)]
+#![allow(clippy::upper_case_acronyms, dead_code)]
 //! helper methods for the tests
 use banyan::{
     index::{CompactSeq, Summarizable},
@@ -93,18 +93,123 @@ pub fn txn(store: MemStore<Sha256Digest>, cache_cap: usize) -> Txn {
     Txn::new(Forest::new(store.clone(), branch_cache), store)
 }
 
-#[allow(dead_code)]
 pub fn create_test_tree<I>(xs: I) -> anyhow::Result<(Tree<TT, u64>, Txn)>
 where
     I: IntoIterator<Item = (Key, u64)>,
     I::IntoIter: Send,
 {
     let store = MemStore::new(usize::max_value(), Sha256Digest::digest);
-    let forest = txn(store, 1000);
+    let forest = txn(store, 1 << 20);
     let mut builder = StreamBuilder::<TT, u64>::debug();
     forest.extend(&mut builder, xs)?;
     forest.assert_invariants(&builder)?;
     Ok((builder.snapshot(), forest))
+}
+
+/// A recipe for a tree, which will either be packed or unpacked
+#[derive(Debug, Clone)]
+pub enum TestTree {
+    Unpacked(UnpackedTestTree),
+    Packed(PackedTestTree),
+}
+
+impl TestTree {
+    pub fn packed(xs: Vec<(Key, u64)>) -> Self {
+        Self::Packed(PackedTestTree(xs))
+    }
+
+    pub fn unpacked(xss: Vec<Vec<(Key, u64)>>) -> Self {
+        Self::Unpacked(UnpackedTestTree(xss))
+    }
+
+    pub fn tree(self) -> anyhow::Result<(Tree<TT, u64>, Txn, Vec<(Key, u64)>)> {
+        let (b, txn, xs) = self.builder()?;
+        Ok((b.snapshot(), txn, xs))
+    }
+
+    pub fn builder(self) -> anyhow::Result<(StreamBuilder<TT, u64>, Txn, Vec<(Key, u64)>)> {
+        match self {
+            Self::Unpacked(x) => x.builder(),
+            Self::Packed(x) => x.builder(),
+        }
+    }
+}
+
+impl Arbitrary for TestTree {
+    fn arbitrary(g: &mut Gen) -> Self {
+        if Arbitrary::arbitrary(g) {
+            Self::Packed(Arbitrary::arbitrary(g))
+        } else {
+            Self::Unpacked(Arbitrary::arbitrary(g))
+        }
+    }
+}
+
+/// Recipe for a packed test tree
+#[derive(Debug, Clone)]
+pub struct PackedTestTree(Vec<(Key, u64)>);
+
+impl PackedTestTree {
+    /// Convert this into an actual tree
+    pub fn builder(self) -> anyhow::Result<(StreamBuilder<TT, u64>, Txn, Vec<(Key, u64)>)> {
+        let store = MemStore::new(usize::max_value(), Sha256Digest::digest);
+        let txn = txn(store, 1 << 20);
+        let mut builder = StreamBuilder::<TT, u64>::debug();
+        let xs = self.0.clone();
+        txn.extend(&mut builder, self.0)?;
+        txn.assert_invariants(&builder)?;
+        Ok((builder, txn, xs))
+    }
+}
+
+impl Arbitrary for PackedTestTree {
+    fn arbitrary(g: &mut Gen) -> Self {
+        Self(Arbitrary::arbitrary(g))
+    }
+}
+
+/// Recipe for an unpacked test tree
+#[derive(Debug, Clone)]
+pub struct UnpackedTestTree(Vec<Vec<(Key, u64)>>);
+
+impl UnpackedTestTree {
+    /// Convert this into an actual tree
+    pub fn builder(self) -> anyhow::Result<(StreamBuilder<TT, u64>, Txn, Vec<(Key, u64)>)> {
+        let store = MemStore::new(usize::max_value(), Sha256Digest::digest);
+        let txn = txn(store, 1 << 20);
+        let mut builder = StreamBuilder::<TT, u64>::debug();
+        let xs = self.0.iter().cloned().flatten().collect();
+        for xs in self.0 {
+            txn.extend_unpacked(&mut builder, xs)?;
+        }
+        txn.assert_invariants(&builder)?;
+        Ok((builder, txn, xs))
+    }
+}
+
+impl Arbitrary for UnpackedTestTree {
+    fn arbitrary(g: &mut Gen) -> Self {
+        let xs: Vec<(Key, u64)> = Arbitrary::arbitrary(g);
+        let mut cuts: Vec<usize> = Arbitrary::arbitrary(g);
+        if !xs.is_empty() {
+            for x in cuts.iter_mut() {
+                *x %= xs.len();
+            }
+            cuts.push(0);
+            cuts.push(xs.len());
+            cuts.sort();
+            cuts.dedup();
+        } else {
+            cuts.clear();
+        }
+        // cut xs in random places
+        let res = cuts
+            .iter()
+            .zip(cuts.iter().skip(1))
+            .map(|(start, end)| xs[*start..*end].iter().cloned().collect::<Vec<_>>())
+            .collect::<Vec<_>>();
+        UnpackedTestTree(res)
+    }
 }
 
 /// Extract all links from a tree

--- a/banyan/tests/common.rs
+++ b/banyan/tests/common.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::upper_case_acronyms, dead_code)]
+#![allow(clippy::upper_case_acronyms, dead_code, clippy::type_complexity)]
 //! helper methods for the tests
 use banyan::{
     index::{CompactSeq, Summarizable},
@@ -197,7 +197,7 @@ impl Arbitrary for UnpackedTestTree {
             }
             cuts.push(0);
             cuts.push(xs.len());
-            cuts.sort();
+            cuts.sort_unstable();
             cuts.dedup();
         } else {
             cuts.clear();
@@ -206,7 +206,7 @@ impl Arbitrary for UnpackedTestTree {
         let res = cuts
             .iter()
             .zip(cuts.iter().skip(1))
-            .map(|(start, end)| xs[*start..*end].iter().cloned().collect::<Vec<_>>())
+            .map(|(start, end)| xs[*start..*end].to_vec())
             .collect::<Vec<_>>();
         UnpackedTestTree(res)
     }


### PR DESCRIPTION
Formerly, only a few select tests were done with unpacked trees. But we frequently have unpacked trees when using extend_unpacked, before packing.

Now, in 50% of all cases the test tree will be crated by chopping the sample values into pieces and creating an unpacked tree.