### PR TITLE
Fix range attached to FilteredChunk when skipping a child

### DIFF
--- a/banyan/src/forest/read.rs
+++ b/banyan/src/forest/read.rs
@@ -198,6 +198,13 @@ where
                     } else {
                         let index = &branch.children[next_idx];
                         head.next_pos(&self.mode);
+                        // calculate the range in advance
+                        let range = match self.mode {
+                            Mode::Forward => self.offset..self.offset.saturating_add(index.count()),
+                            Mode::Backward => {
+                                self.offset.saturating_sub(index.count())..self.offset
+                            }
+                        };
                         // move offset
                         match self.mode {
                             Mode::Forward => self.offset += index.count(),

--- a/banyan/src/index.rs
+++ b/banyan/src/index.rs
@@ -525,6 +525,12 @@ impl FromIterator<()> for UnitSeq {
 #[derive(Debug, Clone, DagCbor)]
 pub struct VecSeq<T: DagCbor>(Vec<T>);
 
+impl<T: DagCbor> AsRef<[T]> for VecSeq<T> {
+    fn as_ref(&self) -> &[T] {
+        &self.0
+    }
+}
+
 impl<T: DagCbor + Clone> CompactSeq for VecSeq<T> {
     type Item = T;
     fn get(&self, index: usize) -> Option<T> {


### PR DESCRIPTION
Formerly it was the range of the entire branch, which is wrong. It does not
matter in most tests, since usually the range is discarded.

Since we turned the recursive traversal to an iterator to save stack, this
code is really very mutable and difficult to read.

The actual fix is just a few LOC, but to get a reproducer I had to do a major extension / overhaul of the test infrastructure. There is now a TestFilter with its own arbitrary that produces more complex filters than previously. Also, the test tree had to gain actually meaningful summaries.

~WIP until we have a test that fails before and passes now~