### PR TITLE
Custom extraction

### DIFF
--- a/banyan/src/forest/index_iter.rs
+++ b/banyan/src/forest/index_iter.rs
@@ -125,7 +125,7 @@ where
                 continue;
             }
 
-            match self.forest.load_node(&self.secrets, &head.index) {
+            match self.forest.node_info(&self.secrets, &head.index) {
                 NodeInfo::Branch(index, branch) => {
                     let branch = match branch.load_cached() {
                         Ok(branch) => branch,

--- a/banyan/src/forest/mod.rs
+++ b/banyan/src/forest/mod.rs
@@ -9,7 +9,7 @@ mod read;
 mod stream;
 mod write;
 pub(crate) use index_iter::IndexIter;
-pub(crate) use read::TreeIter;
+pub(crate) use read::{ChunkVisitor, TreeIter};
 
 /// Trees can be parametrized with the key type and the sequence type. Also, to avoid a dependency
 /// on a link type with all its baggage, we parameterize the link type.

--- a/banyan/src/forest/stream.rs
+++ b/banyan/src/forest/stream.rs
@@ -50,7 +50,7 @@ impl<T: TreeTypes, R: ReadOnlyStore<T::Link>> Forest<T, R> {
         Q: Query<T> + Clone,
         V: BanyanValue,
         E: Send + 'static,
-        F: Send + Sync + 'static + Fn(NodeInfo<T, R>) -> E,
+        F: Send + Sync + 'static + Fn(&NodeInfo<T, R>) -> E,
     {
         let end = *range.end();
         let start_offset_ref = Arc::new(AtomicU64::new(*range.start()));
@@ -104,7 +104,7 @@ impl<T: TreeTypes, R: ReadOnlyStore<T::Link>> Forest<T, R> {
         Q: Query<T> + Clone,
         V: BanyanValue,
         E: Send + 'static,
-        F: Send + Sync + 'static + Fn(NodeInfo<T, R>) -> E,
+        F: Send + Sync + 'static + Fn(&NodeInfo<T, R>) -> E,
     {
         let offset = Arc::new(AtomicU64::new(*range.start()));
         let forest = self.clone();
@@ -151,7 +151,7 @@ impl<T: TreeTypes, R: ReadOnlyStore<T::Link>> Forest<T, R> {
         Q: Query<T> + Clone,
         V: BanyanValue,
         E: Send + 'static,
-        F: Send + Sync + 'static + Fn(NodeInfo<T, R>) -> E,
+        F: Send + Sync + 'static + Fn(&NodeInfo<T, R>) -> E,
     {
         let start = *range.start();
         let end_offset_ref = Arc::new(AtomicU64::new(*range.end()));

--- a/banyan/src/forest/stream.rs
+++ b/banyan/src/forest/stream.rs
@@ -1,6 +1,6 @@
 //! helper methods to stream trees
 use crate::{
-    index::IndexRef,
+    index::NodeInfo,
     store::{BanyanValue, ReadOnlyStore},
     tree::Tree,
     util::{take_until_condition, ToStreamExt},
@@ -50,7 +50,7 @@ impl<T: TreeTypes, R: ReadOnlyStore<T::Link>> Forest<T, R> {
         Q: Query<T> + Clone,
         V: BanyanValue,
         E: Send + 'static,
-        F: Send + Sync + 'static + Fn(IndexRef<T>) -> E,
+        F: Send + Sync + 'static + Fn(NodeInfo<T, R>) -> E,
     {
         let end = *range.end();
         let start_offset_ref = Arc::new(AtomicU64::new(*range.start()));
@@ -104,7 +104,7 @@ impl<T: TreeTypes, R: ReadOnlyStore<T::Link>> Forest<T, R> {
         Q: Query<T> + Clone,
         V: BanyanValue,
         E: Send + 'static,
-        F: Send + Sync + 'static + Fn(IndexRef<T>) -> E,
+        F: Send + Sync + 'static + Fn(NodeInfo<T, R>) -> E,
     {
         let offset = Arc::new(AtomicU64::new(*range.start()));
         let forest = self.clone();
@@ -151,7 +151,7 @@ impl<T: TreeTypes, R: ReadOnlyStore<T::Link>> Forest<T, R> {
         Q: Query<T> + Clone,
         V: BanyanValue,
         E: Send + 'static,
-        F: Send + Sync + 'static + Fn(IndexRef<T>) -> E,
+        F: Send + Sync + 'static + Fn(NodeInfo<T, R>) -> E,
     {
         let start = *range.start();
         let end_offset_ref = Arc::new(AtomicU64::new(*range.end()));

--- a/banyan/src/forest/write.rs
+++ b/banyan/src/forest/write.rs
@@ -296,7 +296,7 @@ where
             return Ok(index.clone());
         }
         let secrets = stream.secrets().clone();
-        Ok(match self.load_node(&secrets, index) {
+        Ok(match self.node_info(&secrets, index) {
             NodeInfo::Leaf(index, leaf) => {
                 tracing::debug!("extending existing leaf");
                 let leaf = leaf.load()?;

--- a/banyan/src/index.rs
+++ b/banyan/src/index.rs
@@ -44,7 +44,6 @@ use crate::{
     CipherOffset, Forest, Secrets,
 };
 use anyhow::{anyhow, Result};
-use derive_more::From;
 use libipld::{
     cbor::{DagCbor, DagCborCodec},
     codec::{Decode, Encode},
@@ -203,13 +202,6 @@ impl<T: TreeTypes> From<BranchIndex<T>> for Index<T> {
     }
 }
 
-/// enum for a leaf or branch index
-#[derive(Debug, From)]
-pub enum IndexRef<'a, T: TreeTypes> {
-    Leaf(&'a LeafIndex<T>),
-    Branch(&'a BranchIndex<T>),
-}
-
 impl<T: TreeTypes> Clone for Index<T> {
     fn clone(&self) -> Self {
         match self {
@@ -220,13 +212,6 @@ impl<T: TreeTypes> Clone for Index<T> {
 }
 
 impl<T: TreeTypes> Index<T> {
-    pub fn as_index_ref(&self) -> IndexRef<T> {
-        match self {
-            Index::Leaf(x) => IndexRef::Leaf(x),
-            Index::Branch(x) => IndexRef::Branch(x),
-        }
-    }
-
     pub fn summarize(&self) -> T::Summary {
         match self {
             Index::Leaf(x) => x.keys.summarize(),

--- a/banyan/src/query.rs
+++ b/banyan/src/query.rs
@@ -7,7 +7,7 @@
 use crate::{
     forest::TreeTypes,
     index::{BranchIndex, CompactSeq, LeafIndex},
-    util::{BoolSliceExt, RangeBoundsExt},
+    util::{MutBoolSliceExt, RangeBoundsExt},
 };
 use std::{fmt::Debug, ops::RangeBounds, sync::Arc};
 

--- a/banyan/src/tree.rs
+++ b/banyan/src/tree.rs
@@ -163,7 +163,8 @@ impl<T: TreeTypes, R: ReadOnlyStore<T::Link>> Forest<T, R> {
         TreeIter::new(
             self.clone(),
             secrets,
-            ChunkVisitor::new(query, mk_extra),
+            query,
+            ChunkVisitor::new(mk_extra),
             index,
         )
     }
@@ -183,7 +184,8 @@ impl<T: TreeTypes, R: ReadOnlyStore<T::Link>> Forest<T, R> {
         TreeIter::new_rev(
             self.clone(),
             secrets,
-            ChunkVisitor::new(query, mk_extra),
+            query,
+            ChunkVisitor::new(mk_extra),
             index,
         )
     }

--- a/banyan/src/tree.rs
+++ b/banyan/src/tree.rs
@@ -149,7 +149,7 @@ impl<T: TreeTypes, R: ReadOnlyStore<T::Link>> Forest<T, R> {
         Q: Query<T>,
         V: BanyanValue,
         E: Send + 'static,
-        F: Fn(NodeInfo<T, R>) -> E + Send + Sync + 'static,
+        F: Fn(&NodeInfo<T, R>) -> E + Send + Sync + 'static,
     >(
         &self,
         secrets: Secrets,
@@ -164,7 +164,7 @@ impl<T: TreeTypes, R: ReadOnlyStore<T::Link>> Forest<T, R> {
         Q: Query<T>,
         V: BanyanValue,
         E: Send + 'static,
-        F: Fn(NodeInfo<T, R>) -> E + Send + Sync + 'static,
+        F: Fn(&NodeInfo<T, R>) -> E + Send + Sync + 'static,
     >(
         &self,
         secrets: Secrets,
@@ -204,7 +204,7 @@ impl<T: TreeTypes, R: ReadOnlyStore<T::Link>> Forest<T, R> {
         let mut edges = vec![];
         let mut nodes: BTreeMap<usize, S> = Default::default();
 
-        let node = self.load_node(secrets, index);
+        let node = self.node_info(secrets, index);
         if let Some(p) = parent_id {
             edges.push((p, next_id));
         }
@@ -386,7 +386,7 @@ impl<T: TreeTypes, R: ReadOnlyStore<T::Link>> Forest<T, R> {
         Q: Query<T>,
         V: BanyanValue,
         E: Send + 'static,
-        F: Fn(NodeInfo<T, R>) -> E + Send + Sync + 'static,
+        F: Fn(&NodeInfo<T, R>) -> E + Send + Sync + 'static,
     {
         match &tree.0 {
             Some((index, secrets, _)) => self
@@ -406,7 +406,7 @@ impl<T: TreeTypes, R: ReadOnlyStore<T::Link>> Forest<T, R> {
         Q: Query<T>,
         V: BanyanValue,
         E: Send + 'static,
-        F: Fn(NodeInfo<T, R>) -> E + Send + Sync + 'static,
+        F: Fn(&NodeInfo<T, R>) -> E + Send + Sync + 'static,
     {
         match &tree.0 {
             Some((index, secrets, _)) => self
@@ -426,7 +426,7 @@ impl<T: TreeTypes, R: ReadOnlyStore<T::Link>> Forest<T, R> {
         Q: Query<T>,
         V: BanyanValue,
         E: Send + 'static,
-        F: Fn(NodeInfo<T, R>) -> E + Send + Sync + 'static,
+        F: Fn(&NodeInfo<T, R>) -> E + Send + Sync + 'static,
     {
         match &tree.0 {
             Some((index, secrets, _)) => self
@@ -446,7 +446,7 @@ impl<T: TreeTypes, R: ReadOnlyStore<T::Link>> Forest<T, R> {
         Q: Query<T>,
         V: BanyanValue,
         E: Send + 'static,
-        F: Fn(NodeInfo<T, R>) -> E + Send + Sync + 'static,
+        F: Fn(&NodeInfo<T, R>) -> E + Send + Sync + 'static,
     {
         match &tree.0 {
             Some((index, secrets, _)) => self

--- a/banyan/src/tree.rs
+++ b/banyan/src/tree.rs
@@ -1,7 +1,10 @@
 //! creation and traversal of banyan trees
 use super::index::*;
 use crate::{
-    forest::{Config, FilteredChunk, Forest, IndexIter, Secrets, Transaction, TreeIter, TreeTypes},
+    forest::{
+        ChunkVisitor, Config, FilteredChunk, Forest, IndexIter, Secrets, Transaction, TreeIter,
+        TreeTypes,
+    },
     store::{BanyanValue, BlockWriter},
 };
 use crate::{query::Query, store::ReadOnlyStore, util::IterExt, StreamBuilder, StreamBuilderState};
@@ -157,7 +160,12 @@ impl<T: TreeTypes, R: ReadOnlyStore<T::Link>> Forest<T, R> {
         index: Index<T>,
         mk_extra: &'static F,
     ) -> impl Iterator<Item = Result<FilteredChunk<(u64, T::Key, V), E>>> {
-        TreeIter::new(self.clone(), secrets, query, index, mk_extra)
+        TreeIter::new(
+            self.clone(),
+            secrets,
+            ChunkVisitor::new(query, mk_extra),
+            index,
+        )
     }
 
     pub(crate) fn traverse_rev0<
@@ -172,7 +180,12 @@ impl<T: TreeTypes, R: ReadOnlyStore<T::Link>> Forest<T, R> {
         index: Index<T>,
         mk_extra: &'static F,
     ) -> impl Iterator<Item = Result<FilteredChunk<(u64, T::Key, V), E>>> {
-        TreeIter::new_rev(self.clone(), secrets, query, index, mk_extra)
+        TreeIter::new_rev(
+            self.clone(),
+            secrets,
+            ChunkVisitor::new(query, mk_extra),
+            index,
+        )
     }
 
     fn index_iter0<Q: Query<T> + Clone + Send + 'static>(

--- a/banyan/src/tree.rs
+++ b/banyan/src/tree.rs
@@ -149,7 +149,7 @@ impl<T: TreeTypes, R: ReadOnlyStore<T::Link>> Forest<T, R> {
         Q: Query<T>,
         V: BanyanValue,
         E: Send + 'static,
-        F: Fn(IndexRef<T>) -> E + Send + Sync + 'static,
+        F: Fn(NodeInfo<T, R>) -> E + Send + Sync + 'static,
     >(
         &self,
         secrets: Secrets,
@@ -164,7 +164,7 @@ impl<T: TreeTypes, R: ReadOnlyStore<T::Link>> Forest<T, R> {
         Q: Query<T>,
         V: BanyanValue,
         E: Send + 'static,
-        F: Fn(IndexRef<T>) -> E + Send + Sync + 'static,
+        F: Fn(NodeInfo<T, R>) -> E + Send + Sync + 'static,
     >(
         &self,
         secrets: Secrets,
@@ -386,7 +386,7 @@ impl<T: TreeTypes, R: ReadOnlyStore<T::Link>> Forest<T, R> {
         Q: Query<T>,
         V: BanyanValue,
         E: Send + 'static,
-        F: Fn(IndexRef<T>) -> E + Send + Sync + 'static,
+        F: Fn(NodeInfo<T, R>) -> E + Send + Sync + 'static,
     {
         match &tree.0 {
             Some((index, secrets, _)) => self
@@ -406,7 +406,7 @@ impl<T: TreeTypes, R: ReadOnlyStore<T::Link>> Forest<T, R> {
         Q: Query<T>,
         V: BanyanValue,
         E: Send + 'static,
-        F: Fn(IndexRef<T>) -> E + Send + Sync + 'static,
+        F: Fn(NodeInfo<T, R>) -> E + Send + Sync + 'static,
     {
         match &tree.0 {
             Some((index, secrets, _)) => self
@@ -426,7 +426,7 @@ impl<T: TreeTypes, R: ReadOnlyStore<T::Link>> Forest<T, R> {
         Q: Query<T>,
         V: BanyanValue,
         E: Send + 'static,
-        F: Fn(IndexRef<T>) -> E + Send + Sync + 'static,
+        F: Fn(NodeInfo<T, R>) -> E + Send + Sync + 'static,
     {
         match &tree.0 {
             Some((index, secrets, _)) => self
@@ -446,7 +446,7 @@ impl<T: TreeTypes, R: ReadOnlyStore<T::Link>> Forest<T, R> {
         Q: Query<T>,
         V: BanyanValue,
         E: Send + 'static,
-        F: Fn(IndexRef<T>) -> E + Send + Sync + 'static,
+        F: Fn(NodeInfo<T, R>) -> E + Send + Sync + 'static,
     {
         match &tree.0 {
             Some((index, secrets, _)) => self

--- a/banyan/src/util.rs
+++ b/banyan/src/util.rs
@@ -33,27 +33,31 @@ pub(crate) fn is_sorted<T: Ord>(iter: impl Iterator<Item = T>) -> bool {
     iter.collect::<Vec<_>>().windows(2).all(|x| x[0] <= x[1])
 }
 
-/// Some extensions to make bool slices nicer to work with
 pub trait BoolSliceExt {
-    /// Set all bools to false
-    fn clear(self);
-
     /// true if any of the fields is true
     fn any(self) -> bool;
+}
+
+impl BoolSliceExt for &[bool] {
+    fn any(self) -> bool {
+        self.iter().any(|x| *x)
+    }
+}
+
+/// Some extensions to make bool slices nicer to work with
+pub trait MutBoolSliceExt {
+    /// Set all bools to false
+    fn clear(self);
 
     /// or combination with another bool slice, with false as default for where
     /// the sizes don't match.
     fn or_with(self, rhs: &[bool]);
 }
 
-impl BoolSliceExt for &mut [bool] {
+impl MutBoolSliceExt for &mut [bool] {
     fn clear(self) {
         // todo: use fill https://github.com/rust-lang/rust/issues/70758 is merged
         self.iter_mut().for_each(|x| *x = false);
-    }
-
-    fn any(self) -> bool {
-        self.iter().any(|x| *x)
     }
 
     fn or_with(self, rhs: &[bool]) {


### PR DESCRIPTION
Refactor TreeIter so that it is more flexible. Basically the "materialization" of the values is delegated to a vistor trait, with an adapter for the current signature.

That way, we have the choice what to materialize. E.g. just keys, just values, part of the keys, ...
