### PR TITLE
Add optional prometheus metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,10 +103,12 @@ dependencies = [
  "futures",
  "generic-array",
  "hex",
+ "lazy_static",
  "libipld",
  "maplit",
  "multihash",
  "parking_lot",
+ "prometheus",
  "quickcheck",
  "quickcheck_async",
  "quickcheck_macros",
@@ -1291,6 +1293,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5986aa8d62380092d2f50f8b1cdba9cb9b6731ffd4b25b51fd126b6c3e05b99c"
+dependencies = [
+ "cfg-if 1.0.0",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot",
+ "protobuf",
+ "thiserror",
+]
+
+[[package]]
 name = "prost"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1340,6 +1357,12 @@ dependencies = [
  "bytes",
  "prost",
 ]
+
+[[package]]
+name = "protobuf"
+version = "2.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db50e77ae196458ccd3dc58a31ea1a90b0698ab1b7928d89f644c25d72070267"
 
 [[package]]
 name = "quickcheck"

--- a/banyan/Cargo.toml
+++ b/banyan/Cargo.toml
@@ -10,7 +10,7 @@ description = "Persistent indexable tree data structure"
 repository = "https://github.com/actyx/banyan/"
 
 [features]
-metrics = ["prometheus"]
+metrics = ["prometheus", "lazy_static"]
 default = ["metrics"]
 
 [dependencies]
@@ -19,7 +19,7 @@ chacha20 = "0.7.1"
 derive_more = "0.99.13"
 fnv = "1.0.7"
 futures = { version = "0.3.14", features = ["thread-pool"] }
-lazy_static = "1.4.0"
+lazy_static = { version = "1.4.0", optional = true }
 libipld = { version = "0.12.0", features = ["unleashed"] }
 maplit = "1.0.2"
 parking_lot = "0.11.1"

--- a/banyan/Cargo.toml
+++ b/banyan/Cargo.toml
@@ -15,9 +15,11 @@ chacha20 = "0.7.1"
 derive_more = "0.99.13"
 fnv = "1.0.7"
 futures = { version = "0.3.14", features = ["thread-pool"] }
+lazy_static = "1.4.0"
 libipld = { version = "0.12.0", features = ["unleashed"] }
 maplit = "1.0.2"
 parking_lot = "0.11.1"
+prometheus = "0.12.0"
 smallvec = "1.6.1"
 tracing = "0.1.25"
 weight-cache = "0.2.3"

--- a/banyan/Cargo.toml
+++ b/banyan/Cargo.toml
@@ -9,6 +9,10 @@ categories = ["data-structures"]
 description = "Persistent indexable tree data structure"
 repository = "https://github.com/actyx/banyan/"
 
+[features]
+metrics = ["prometheus"]
+default = ["metrics"]
+
 [dependencies]
 anyhow = "1.0.40"
 chacha20 = "0.7.1"
@@ -19,7 +23,7 @@ lazy_static = "1.4.0"
 libipld = { version = "0.12.0", features = ["unleashed"] }
 maplit = "1.0.2"
 parking_lot = "0.11.1"
-prometheus = "0.12.0"
+prometheus = { version = "0.12.0", optional = true }
 smallvec = "1.6.1"
 tracing = "0.1.25"
 weight-cache = "0.2.3"

--- a/banyan/src/forest/mod.rs
+++ b/banyan/src/forest/mod.rs
@@ -5,14 +5,16 @@ use core::{fmt::Debug, hash::Hash, iter::FromIterator, ops::Range};
 use libipld::cbor::DagCbor;
 use std::{fmt::Display, sync::Arc};
 mod index_iter;
+#[cfg(feature = "metrics")]
+mod prom;
 mod read;
 mod stream;
 mod write;
 pub(crate) use index_iter::IndexIter;
 #[cfg(feature = "metrics")]
-use prometheus::Registry;
+pub(crate) use prom::register;
 #[cfg(feature = "metrics")]
-pub(crate) use read::register;
+use prometheus::Registry;
 pub(crate) use read::{ChunkVisitor, TreeIter};
 
 /// Trees can be parametrized with the key type and the sequence type. Also, to avoid a dependency

--- a/banyan/src/forest/mod.rs
+++ b/banyan/src/forest/mod.rs
@@ -3,13 +3,14 @@ use super::index::*;
 use crate::store::{BlockWriter, BranchCache, ReadOnlyStore};
 use core::{fmt::Debug, hash::Hash, iter::FromIterator, ops::Range};
 use libipld::cbor::DagCbor;
+use prometheus::Registry;
 use std::{fmt::Display, sync::Arc};
 mod index_iter;
 mod read;
 mod stream;
 mod write;
 pub(crate) use index_iter::IndexIter;
-pub(crate) use read::{ChunkVisitor, TreeIter};
+pub(crate) use read::{register, ChunkVisitor, TreeIter};
 
 /// Trees can be parametrized with the key type and the sequence type. Also, to avoid a dependency
 /// on a link type with all its baggage, we parameterize the link type.
@@ -50,6 +51,7 @@ pub trait TreeTypes: Debug + Send + Sync + Clone + 'static {
 pub struct ForestInner<T: TreeTypes, R> {
     pub(crate) store: R,
     pub(crate) branch_cache: BranchCache<T>,
+    pub(crate) registry: Registry,
 }
 
 #[derive(Debug)]
@@ -63,9 +65,11 @@ impl<TT: TreeTypes, R> Clone for Forest<TT, R> {
 
 impl<TT: TreeTypes, R: Clone> Forest<TT, R> {
     pub fn new(store: R, branch_cache: BranchCache<TT>) -> Self {
+        let registry = Registry::new();
         Self(Arc::new(ForestInner {
             store,
             branch_cache,
+            registry,
         }))
     }
 

--- a/banyan/src/forest/prom.rs
+++ b/banyan/src/forest/prom.rs
@@ -1,0 +1,51 @@
+use lazy_static::lazy_static;
+use prometheus::{exponential_buckets, Histogram, HistogramOpts, Registry};
+
+lazy_static! {
+    pub static ref LEAF_LOAD_HIST: Histogram = Histogram::with_opts(
+        HistogramOpts::new("leaf_load_time", "Complete time to load leafs",)
+            .namespace("banyan")
+            .buckets(exponential_buckets(0.00001, 2.0, 17).unwrap()),
+    )
+    .unwrap();
+    pub static ref BRANCH_LOAD_HIST: Histogram = Histogram::with_opts(
+        HistogramOpts::new("branch_load_time", "Complete time to load branches",)
+            .namespace("banyan")
+            .buckets(exponential_buckets(0.00001, 2.0, 17).unwrap()),
+    )
+    .unwrap();
+    pub static ref LEAF_STORE_HIST: Histogram = Histogram::with_opts(
+        HistogramOpts::new("leaf_store_time", "Complete time to store leafs",)
+            .namespace("banyan")
+            .buckets(exponential_buckets(0.00001, 2.0, 17).unwrap()),
+    )
+    .unwrap();
+    pub static ref BRANCH_STORE_HIST: Histogram = Histogram::with_opts(
+        HistogramOpts::new("branch_store_time", "Complete time to store branches",)
+            .namespace("banyan")
+            .buckets(exponential_buckets(0.00001, 2.0, 17).unwrap()),
+    )
+    .unwrap();
+    pub static ref BLOCK_PUT_HIST: Histogram = Histogram::with_opts(
+        HistogramOpts::new("block_put_time", "Complete time spent in block put",)
+            .namespace("banyan")
+            .buckets(exponential_buckets(0.00001, 2.0, 17).unwrap()),
+    )
+    .unwrap();
+    pub static ref BLOCK_GET_HIST: Histogram = Histogram::with_opts(
+        HistogramOpts::new("block_get_time", "Complete time spent in block get",)
+            .namespace("banyan")
+            .buckets(exponential_buckets(0.00001, 2.0, 17).unwrap()),
+    )
+    .unwrap();
+}
+
+pub(crate) fn register(registry: &Registry) -> anyhow::Result<()> {
+    registry.register(Box::new(LEAF_LOAD_HIST.clone()))?;
+    registry.register(Box::new(BRANCH_LOAD_HIST.clone()))?;
+    registry.register(Box::new(LEAF_STORE_HIST.clone()))?;
+    registry.register(Box::new(BRANCH_STORE_HIST.clone()))?;
+    registry.register(Box::new(BLOCK_PUT_HIST.clone()))?;
+    registry.register(Box::new(BLOCK_GET_HIST.clone()))?;
+    Ok(())
+}

--- a/banyan/src/forest/prom.rs
+++ b/banyan/src/forest/prom.rs
@@ -38,6 +38,18 @@ lazy_static! {
             .buckets(exponential_buckets(0.00001, 2.0, 17).unwrap()),
     )
     .unwrap();
+    pub static ref BLOCK_PUT_SIZE_HIST: Histogram = Histogram::with_opts(
+        HistogramOpts::new("block_put_size", "Size of blocks being written",)
+            .namespace("banyan")
+            .buckets(exponential_buckets(64.0, 2.0, 16).unwrap()),
+    )
+    .unwrap();
+    pub static ref BLOCK_GET_SIZE_HIST: Histogram = Histogram::with_opts(
+        HistogramOpts::new("block_get_size", "Size of blocks being read",)
+            .namespace("banyan")
+            .buckets(exponential_buckets(64.0, 2.0, 16).unwrap()),
+    )
+    .unwrap();
 }
 
 pub(crate) fn register(registry: &Registry) -> anyhow::Result<()> {
@@ -47,5 +59,7 @@ pub(crate) fn register(registry: &Registry) -> anyhow::Result<()> {
     registry.register(Box::new(BRANCH_STORE_HIST.clone()))?;
     registry.register(Box::new(BLOCK_PUT_HIST.clone()))?;
     registry.register(Box::new(BLOCK_GET_HIST.clone()))?;
+    registry.register(Box::new(BLOCK_PUT_SIZE_HIST.clone()))?;
+    registry.register(Box::new(BLOCK_GET_SIZE_HIST.clone()))?;
     Ok(())
 }

--- a/banyan/src/forest/read.rs
+++ b/banyan/src/forest/read.rs
@@ -425,7 +425,12 @@ where
     fn get_block(&self, link: &T::Link) -> anyhow::Result<Box<[u8]>> {
         #[cfg(feature = "metrics")]
         let _timer = prom::BLOCK_GET_HIST.start_timer();
-        self.store.get(link)
+        let res = self.store.get(link);
+        #[cfg(feature = "metrics")]
+        if let Ok(x) = &res {
+            prom::BLOCK_GET_SIZE_HIST.observe(x.len() as f64);
+        }
+        res
     }
 
     /// load a branch given a branch index

--- a/banyan/src/forest/stream.rs
+++ b/banyan/src/forest/stream.rs
@@ -106,76 +106,30 @@ impl<T: TreeTypes, R: ReadOnlyStore<T::Link>> Forest<T, R> {
         E: Send + 'static,
         F: Send + Sync + 'static + Fn(&NodeInfo<T, R>) -> E,
     {
-        let end = *range.end();
-        let start_offset_ref = Arc::new(AtomicU64::new(*range.start()));
+        let offset = Arc::new(AtomicU64::new(*range.start()));
         let forest = self.clone();
-        let result = trees
+        trees
             .filter_map(move |tree| future::ready(tree.into_inner()))
             .flat_map(move |(index, secrets, _)| {
                 // create an intersection of a range query and the main query
                 // and wrap it in an arc so it is cheap to clone
-                let range = start_offset_ref.load(Ordering::SeqCst)..=*range.end();
+                let range = offset.load(Ordering::SeqCst)..=*range.end();
                 let query = AndQuery(OffsetRangeQuery::from(range), query.clone()).boxed();
-                let start_offset_ref = start_offset_ref.clone();
+                let offset = offset.clone();
                 let iter = forest
                     .clone()
                     .traverse0(secrets, query, index, mk_extra)
                     .take_while(move |result| {
                         if let Ok(chunk) = result {
                             // update the offset
-                            start_offset_ref.fetch_max(chunk.range.end, Ordering::SeqCst);
+                            offset.fetch_max(chunk.range.end, Ordering::SeqCst);
                         }
                         // abort at the first non-ok offset
                         result.is_ok()
                     });
                 iter.into_stream(1, thread_pool.clone())
-            });
-        // make sure we terminate when `end` is reached
-        take_until_condition(result, move |chunk| match chunk {
-            // end is inclusive, whereas `chunk.range.end` is exclusive
-            Ok(chunk) => chunk.range.end > end,
-            Err(_) => true,
-        })
+            })
     }
-    // pub fn stream_trees_chunked_threaded<S, Q, V, E, F>(
-    //     &self,
-    //     query: Q,
-    //     trees: S,
-    //     range: RangeInclusive<u64>,
-    //     mk_extra: &'static F,
-    //     thread_pool: ThreadPool,
-    // ) -> impl Stream<Item = anyhow::Result<FilteredChunk<(u64, T::Key, V), E>>> + Send + 'static
-    // where
-    //     S: Stream<Item = Tree<T, V>> + Send + 'static,
-    //     Q: Query<T> + Clone,
-    //     V: BanyanValue,
-    //     E: Send + 'static,
-    //     F: Send + Sync + 'static + Fn(&NodeInfo<T, R>) -> E,
-    // {
-    //     let offset = Arc::new(AtomicU64::new(*range.start()));
-    //     let forest = self.clone();
-    //     trees
-    //         .filter_map(move |tree| future::ready(tree.into_inner()))
-    //         .flat_map(move |(index, secrets, _)| {
-    //             // create an intersection of a range query and the main query
-    //             // and wrap it in an arc so it is cheap to clone
-    //             let range = offset.load(Ordering::SeqCst)..=*range.end();
-    //             let query = AndQuery(OffsetRangeQuery::from(range), query.clone()).boxed();
-    //             let offset = offset.clone();
-    //             let iter = forest
-    //                 .clone()
-    //                 .traverse0(secrets, query, index, mk_extra)
-    //                 .take_while(move |result| {
-    //                     if let Ok(chunk) = result {
-    //                         // update the offset
-    //                         offset.fetch_max(chunk.range.end, Ordering::SeqCst);
-    //                     }
-    //                     // abort at the first non-ok offset
-    //                     result.is_ok()
-    //                 });
-    //             iter.into_stream(1, thread_pool.clone())
-    //         })
-    // }
 
     /// Given a sequence of roots, will stream chunks in reverse order until it arrives at `range.start()`.
     ///

--- a/banyan/src/forest/write.rs
+++ b/banyan/src/forest/write.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "metrics")]
+use super::prom;
 use crate::{
     forest::{BranchResult, Config, CreateMode, Forest, Transaction, TreeTypes},
     index::{zip_with_offset_ref, NodeInfo},
@@ -17,7 +19,7 @@ use crate::{
 };
 use anyhow::{ensure, Result};
 use libipld::cbor::DagCbor;
-use std::{iter, time::Instant};
+use std::iter;
 
 /// basic random access append only tree
 impl<T, R, W> Transaction<T, R, W>
@@ -40,6 +42,12 @@ where
         self.extend_leaf(&[], None, from, stream)
     }
 
+    fn put_block(&self, data: Vec<u8>) -> anyhow::Result<T::Link> {
+        #[cfg(feature = "metrics")]
+        let _timer = prom::BLOCK_PUT_HIST.start_timer();
+        self.writer.put(data)
+    }
+
     /// Creates a leaf from a sequence that either contains all items from the sequence, or is full
     ///
     /// The result is the index of the leaf. The iterator will contain the elements that did not fit.
@@ -50,7 +58,8 @@ where
         from: &mut iter::Peekable<impl Iterator<Item = (T::Key, V)>>,
         stream: &mut StreamBuilderState,
     ) -> Result<LeafIndex<T>> {
-        let t0 = Instant::now();
+        #[cfg(feature = "metrics")]
+        let _timer = prom::LEAF_STORE_HIST.start_timer();
         assert!(from.peek().is_some());
         let mut keys = keys.map(|keys| keys.to_vec()).unwrap_or_default();
         let (data, sealed) = ZstdDagCborSeq::fill(
@@ -69,9 +78,8 @@ where
             &mut stream.offset,
         )?;
         let keys = keys.into_iter().collect::<T::KeySeq>();
-        let encrypted_len = encrypted.len();
         // store leaf
-        let link = self.writer.put(encrypted)?;
+        let link = self.put_block(encrypted)?;
         let index: LeafIndex<T> = LeafIndex {
             link: Some(link),
             value_bytes,
@@ -83,11 +91,6 @@ where
             index.keys.count(),
             index.value_bytes,
             index.sealed
-        );
-        tracing::debug!(
-            "extend_leaf {} {}",
-            t0.elapsed().as_secs_f64(),
-            encrypted_len
         );
         Ok(index)
     }
@@ -349,14 +352,13 @@ where
         items: &[Index<T>],
         stream: &mut StreamBuilderState,
     ) -> Result<(T::Link, u64)> {
-        let t0 = Instant::now();
+        #[cfg(feature = "metrics")]
+        let _timer = prom::BRANCH_STORE_HIST.start_timer();
         let level = stream.config().zstd_level;
         let key = *stream.index_key();
         let cbor = serialize_compressed(&key, nonce::<T>(), &mut stream.offset, &items, level)?;
         let len = cbor.len() as u64;
-        let result = Ok((self.writer.put(cbor)?, len));
-        tracing::debug!("persist_branch {}", t0.elapsed().as_secs_f64());
-        result
+        Ok((self.put_block(cbor)?, len))
     }
 
     pub(crate) fn retain0<Q: Query<T> + Send + Sync>(

--- a/banyan/src/forest/write.rs
+++ b/banyan/src/forest/write.rs
@@ -45,6 +45,8 @@ where
     fn put_block(&self, data: Vec<u8>) -> anyhow::Result<T::Link> {
         #[cfg(feature = "metrics")]
         let _timer = prom::BLOCK_PUT_HIST.start_timer();
+        #[cfg(feature = "metrics")]
+        prom::BLOCK_PUT_SIZE_HIST.observe(data.len() as f64);
         self.writer.put(data)
     }
 

--- a/banyan/src/lib.rs
+++ b/banyan/src/lib.rs
@@ -81,7 +81,7 @@ extern crate quickcheck_macros;
 
 /// Register all prometheus metrics
 #[cfg(feature = "metrics")]
-pub fn register(registry: Registry) -> anyhow::Result<()> {
+pub fn register(registry: &Registry) -> anyhow::Result<()> {
     forest::register(registry)?;
     Ok(())
 }

--- a/banyan/src/lib.rs
+++ b/banyan/src/lib.rs
@@ -63,8 +63,10 @@ pub mod store;
 mod stream_builder;
 mod tree;
 mod util;
-use prometheus::Registry;
 use stream_builder::{CipherOffset, StreamBuilderState};
+
+#[cfg(feature = "metrics")]
+use prometheus::Registry;
 
 pub use chacha20;
 pub use forest::{Config, FilteredChunk, Forest, Secrets, Transaction, TreeTypes};
@@ -78,6 +80,7 @@ extern crate quickcheck;
 extern crate quickcheck_macros;
 
 /// Register all prometheus metrics
+#[cfg(feature = "metrics")]
 pub fn register(registry: Registry) -> anyhow::Result<()> {
     forest::register(registry)?;
     Ok(())

--- a/banyan/src/lib.rs
+++ b/banyan/src/lib.rs
@@ -63,6 +63,7 @@ pub mod store;
 mod stream_builder;
 mod tree;
 mod util;
+use prometheus::Registry;
 use stream_builder::{CipherOffset, StreamBuilderState};
 
 pub use chacha20;
@@ -75,3 +76,9 @@ extern crate quickcheck;
 #[cfg(test)]
 #[macro_use(quickcheck)]
 extern crate quickcheck_macros;
+
+/// Register all prometheus metrics
+pub fn register(registry: Registry) -> anyhow::Result<()> {
+    forest::register(registry)?;
+    Ok(())
+}


### PR DESCRIPTION
I had a hard time figuring out a set of metrics that is not overwhelming, but this seems to work reasonably well. It is not very fine grained, but it gives you a rough idea what the thing is doing overall.

E.g. this is what you get when running the pond integration test with 8 local linux hosts yields the following metrics (dumping more frequently so I see them):

```
AX_CI_HOSTS=8linux.yaml npm test pond | grep -A 300 got_metrics | grep -A 1 time_sum

...

2021-07-14T07:17:13.669Z node local-linux-8 Actyx stdout: banyan_block_get_time_sum 11.24307093500005
2021-07-14T07:17:13.669Z node local-linux-8 Actyx stdout: banyan_block_get_time_count 48033
--
2021-07-14T07:17:13.669Z node local-linux-8 Actyx stdout: banyan_block_put_time_sum 1.7594724890000006
2021-07-14T07:17:13.669Z node local-linux-8 Actyx stdout: banyan_block_put_time_count 1559
--
2021-07-14T07:17:13.669Z node local-linux-8 Actyx stdout: banyan_branch_load_time_sum 2.9276649789999785
2021-07-14T07:17:13.669Z node local-linux-8 Actyx stdout: banyan_branch_load_time_count 8291
--
2021-07-14T07:17:13.669Z node local-linux-8 Actyx stdout: banyan_branch_store_time_sum 1.3235776810000015
2021-07-14T07:17:13.669Z node local-linux-8 Actyx stdout: banyan_branch_store_time_count 1037
--
2021-07-14T07:17:13.669Z node local-linux-8 Actyx stdout: banyan_leaf_load_time_sum 5.6611070490000515
2021-07-14T07:17:13.669Z node local-linux-8 Actyx stdout: banyan_leaf_load_time_count 34957
--
2021-07-14T07:17:13.669Z node local-linux-8 Actyx stdout: banyan_leaf_store_time_sum 0.6494339429999996
2021-07-14T07:17:13.669Z node local-linux-8 Actyx stdout: banyan_leaf_store_time_count 522
```

so it spends most of the db time getting blocks, and focused on banyan it spends most of the time loading leafs (this metric is the total time including decryption, decompression and decoding).

We are not going to optimize things just now, but if we wanted to this would give us a good idea where to start.