### PR TITLE
Install rust 1.65.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,9 +16,13 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: fmt 
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: 1.65.0
+        components: "clippy, rustfmt"
+    - name: fmt
       run: cargo fmt --all -- --check
-    - name: clippy 
+    - name: clippy
       run: cargo --locked clippy --all-targets -- -D warnings
     - name: Build
       run: cargo build --locked --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,21 +11,54 @@ env:
 
 jobs:
   build:
-
+    name: Build
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
     - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: 1.65.0
-        components: "clippy, rustfmt"
+    - uses: swatinem/rust-cache@v1
+    - name: Build
+      run: cargo build --locked --verbose
+
+  format:
+    needs: [build]
+    name: format
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: 1.65.0
+        components: "rustfmt"
     - uses: swatinem/rust-cache@v1
     - name: fmt
       run: cargo fmt --all -- --check
+
+  clippy:
+    needs: [build]
+    name: clippy
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: 1.65.0
+        components: "clippy"
+    - uses: swatinem/rust-cache@v1
     - name: clippy
       run: cargo --locked clippy --all-targets -- -D warnings
-    - name: Build
-      run: cargo build --locked --verbose
+
+  test:
+    needs: [build]
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: 1.65.0
+    - uses: swatinem/rust-cache@v1
     - name: Run tests
       run: cargo test --all-features --locked --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: 1.65.0
-    - uses: swatinem/rust-cache@v1
+    - uses: swatinem/rust-cache@v2
     - name: Build
       run: cargo build --locked --verbose
 
@@ -32,7 +32,7 @@ jobs:
       with:
         toolchain: 1.65.0
         components: "rustfmt"
-    - uses: swatinem/rust-cache@v1
+    - uses: swatinem/rust-cache@v2
     - name: fmt
       run: cargo fmt --all -- --check
 
@@ -46,7 +46,7 @@ jobs:
       with:
         toolchain: 1.65.0
         components: "clippy"
-    - uses: swatinem/rust-cache@v1
+    - uses: swatinem/rust-cache@v2
     - name: clippy
       run: cargo --locked clippy --all-targets -- -D warnings
 
@@ -59,6 +59,6 @@ jobs:
     - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: 1.65.0
-    - uses: swatinem/rust-cache@v1
+    - uses: swatinem/rust-cache@v2
     - name: Run tests
       run: cargo test --all-features --locked --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,6 +20,7 @@ jobs:
       with:
         toolchain: 1.65.0
         components: "clippy, rustfmt"
+    - uses: swatinem/rust-cache@v1
     - name: fmt
       run: cargo fmt --all -- --check
     - name: clippy

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,9 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: dtolnay/rust-toolchain@master
-      with:
-        toolchain: 1.65.0
+    - uses: dtolnay/rust-toolchain@1.65.0
     - uses: swatinem/rust-cache@v2
     - name: Build
       run: cargo build --locked --verbose
@@ -28,9 +26,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: dtolnay/rust-toolchain@master
+    - uses: dtolnay/rust-toolchain@1.65.0
       with:
-        toolchain: 1.65.0
         components: "rustfmt"
     - uses: swatinem/rust-cache@v2
     - name: fmt
@@ -42,9 +39,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: dtolnay/rust-toolchain@master
+    - uses: dtolnay/rust-toolchain@1.65.0
       with:
-        toolchain: 1.65.0
         components: "clippy"
     - uses: swatinem/rust-cache@v2
     - name: clippy
@@ -56,9 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: dtolnay/rust-toolchain@master
-      with:
-        toolchain: 1.65.0
+    - uses: dtolnay/rust-toolchain@1.65.0
     - uses: swatinem/rust-cache@v2
     - name: Run tests
       run: cargo test --all-features --locked --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: 1.65.0
@@ -27,7 +27,7 @@ jobs:
     name: format
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: 1.65.0
@@ -41,7 +41,7 @@ jobs:
     name: clippy
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: 1.65.0
@@ -55,7 +55,7 @@ jobs:
     name: test
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: 1.65.0

--- a/banyan-utils/src/bin/cli.rs
+++ b/banyan-utils/src/bin/cli.rs
@@ -60,7 +60,7 @@ impl FromStr for Storage {
     fn from_str(s: &str) -> Result<Self> {
         let s = match s {
             "memory" => Self::Memory(MemStore::new(usize::max_value(), Sha256Digest::new)),
-            "ipfs" => Self::Ipfs(IpfsStore::new()),
+            "ipfs" => Self::Ipfs(IpfsStore::default()),
             x => Self::Sqlite(SqliteStore::new(BlockStore::open(
                 x,
                 ipfs_sqlite_block_store::Config::default(),

--- a/banyan-utils/src/ipfs.rs
+++ b/banyan-utils/src/ipfs.rs
@@ -131,14 +131,8 @@ pub fn block_put(data: &[u8], codec: u64, pin: bool) -> Result<Cid> {
     Ok(cid)
 }
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct IpfsStore;
-
-impl IpfsStore {
-    pub fn new() -> Self {
-        Self
-    }
-}
 
 impl ReadOnlyStore<Sha256Digest> for IpfsStore {
     fn get(&self, link: &Sha256Digest) -> Result<Box<[u8]>> {


### PR DESCRIPTION
In #115 I get clippy errors although locally everything runs fine with rust 1.65.0 and nightly.

Because the current action execution does not list what rust version is used, lets explicitely install 1.65.0.